### PR TITLE
Create a 0.3.1 version of ekka that supports retry autoclustering and is compatible with emq24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 .PHONY: tests
 
 PROJECT = ekka
-PROJECT_DESCRIPTION = Autocluster and Autoheal for EMQ
+PROJECT_DESCRIPTION = Autocluster and Autoheal for EMQ X Broker
 PROJECT_VERSION = 0.3
 
-DEPS = lager jsx
-dep_jsx   = git https://github.com/talentdeficit/jsx
+DEPS = jsx
+dep_jsx = git https://github.com/talentdeficit/jsx
+
+BUILD_DEPS = lager
 dep_lager = git https://github.com/basho/lager master
 
 LOCAL_DEPS = mnesia inets
@@ -23,7 +25,7 @@ TEST_ERLC_OPTS += +'{parse_transform, lager_transform}'
 
 EUNIT_OPTS = verbose
 
-CT_SUITES = ekka ekka_lib ekka_autocluster
+CT_SUITES = ekka ekka_lib ekka_autocluster ekka_locker
 
 CT_OPTS = -cover test/ct.cover.spec -erl_args -name ekka_ct@127.0.0.1
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PROJECT = ekka
 PROJECT_DESCRIPTION = Autocluster and Autoheal for EMQ X Broker
-PROJECT_VERSION = 0.3
+PROJECT_VERSION = 0.3.1
 
 DEPS = jsx
 dep_jsx = git https://github.com/talentdeficit/jsx

--- a/README.md
+++ b/README.md
@@ -249,6 +249,13 @@ Cuttlefish style config:
 cluster.autoclean = 5m
 ```
 
+## Lock Service
+
+Ekka implements a simple distributed lock service in 0.3 release.  The Lock APIs:
+
+TODO:
+
+
 ## License
 
 Apache License Version 2.0

--- a/data/app.mcast.config
+++ b/data/app.mcast.config
@@ -4,7 +4,7 @@
   {cluster_name,ekka},
   {cluster_discovery, {mcast, [
     {addr,{239,192,0,1}},
-    {ports,[4369,4370]},
+    {ports,[4369,4370,4371,4372,4373]},
     {iface,{0,0,0,0}},
     {ttl, 255},
     {loop,true}]}}

--- a/data/app.mcast.config
+++ b/data/app.mcast.config
@@ -1,0 +1,11 @@
+[{ekka, [
+  {cluster_autoheal,true},
+  {cluster_autoclean,300000},
+  {cluster_name,ekka},
+  {cluster_discovery, {mcast, [
+    {addr,{239,192,0,1}},
+    {ports,[4369,4370]},
+    {iface,{0,0,0,0}},
+    {ttl, 255},
+    {loop,true}]}}
+]}].

--- a/etc/ekka.conf.example
+++ b/etc/ekka.conf.example
@@ -1,10 +1,12 @@
-
 ##--------------------------------------------------------------------
 ## Cluster
 ##--------------------------------------------------------------------
 
 ## Cluster name.
 cluster.name = ekka
+
+## Cluster enabled?
+cluster.enable = true
 
 ## Cluster auto-discovery strategy.
 ##
@@ -122,6 +124,11 @@ cluster.autoclean = 5m
 ## Value: String
 ## cluster.k8s.service_name = ekka
 
+## The name space of k8s
+##
+## Value: String
+## cluster.k8s.namespace = default
+
 ## The address type is used to extract host from k8s service.
 ##
 ## Value: ip | dns
@@ -131,3 +138,4 @@ cluster.autoclean = 5m
 ##
 ## Value: String
 ## cluster.k8s.app_name = ekka
+

--- a/etc/ekka.conf.example
+++ b/etc/ekka.conf.example
@@ -3,10 +3,16 @@
 ##--------------------------------------------------------------------
 
 ## Cluster name.
+##
+## Value: String
 cluster.name = ekka
 
-## Cluster enabled?
-cluster.enable = true
+## Enable cluster mode.
+##
+## Value: on | off
+##
+## Default: on
+cluster.enable = on
 
 ## Cluster auto-discovery strategy.
 ##

--- a/etc/ekka.config.example
+++ b/etc/ekka.config.example
@@ -25,6 +25,8 @@
 %% Clustering on k8s
 %% {cluster_discovery, {k8s, [
 %%                       {apiserver, "http://10.110.111.204:8080"},
+%%                       {namespace, "default"},
+%%                       {address_type, ip},
 %%                       {app, ekka}
 %%                     ]}},
 

--- a/include/ekka.hrl
+++ b/include/ekka.hrl
@@ -6,7 +6,7 @@
 -type(member_address() :: {inet:ip_address(), inet:port_number()}).
 
 -record(member, { node   :: node(),
-                  addr   :: member_address(),
+                  addr   :: undefined | member_address(),
                   guid   :: ekka_guid:guid(),
                   hash   :: pos_integer(),
                   status :: member_status(),
@@ -14,4 +14,3 @@
                   ltime  :: erlang:timestamp() }).
 
 -type(member() :: #member{}).
-

--- a/include/ekka.hrl
+++ b/include/ekka.hrl
@@ -1,4 +1,6 @@
 
+-type(cluster() :: atom()).
+
 -type(member_status() :: joining | up | healing | leaving | down).
 
 -type(member_address() :: {inet:ip_address(), inet:port_number()}).
@@ -6,10 +8,10 @@
 -record(member, { node   :: node(),
                   addr   :: member_address(),
                   guid   :: ekka_guid:guid(),
+                  hash   :: pos_integer(),
                   status :: member_status(),
                   mnesia :: running | stopped | false,
-                  ltime  :: erlang:timestamp()
-                }).
+                  ltime  :: erlang:timestamp() }).
 
 -type(member() :: #member{}).
 

--- a/priv/ekka.schema
+++ b/priv/ekka.schema
@@ -8,6 +8,12 @@
   {datatype, atom}
 ]}.
 
+%% @doc Cluster enable
+{mapping, "cluster.enable", "ekka.cluster_enable", [
+  {default, on},
+  {datatype, flag}
+]}.
+
 %% @doc Cluster discovery
 {mapping, "cluster.discovery", "ekka.cluster_discovery", [
   {default, manual},

--- a/scripts/cluster.mcast.sh
+++ b/scripts/cluster.mcast.sh
@@ -1,0 +1,4 @@
+
+erl -pa ebin/ -pa deps/*/ebin -name ekka1@127.0.0.1 -setcookie cookie -config data/app.mcast -s ekka -s ekka autocluster
+
+erl -pa ebin/ -pa deps/*/ebin -name ekka2@127.0.0.1 -setcookie cookie -config data/app.mcast -s ekka -s ekka autocluster

--- a/src/ekka.app.src
+++ b/src/ekka.app.src
@@ -1,6 +1,6 @@
 {application,ekka,
              [{description,"Autocluster and Autoheal for EMQ"},
-              {vsn,"0.3"},
+              {vsn,"0.3.1"},
               {modules,[]},
               {env, [
                 {cluster_autoheal, true},

--- a/src/ekka.app.src
+++ b/src/ekka.app.src
@@ -8,5 +8,5 @@
                 {cluster_discovery, {manual, []}}
               ]},
               {registered,[ekka_sup,ekka_membership,ekka_cluster_sup,ekka_node_monitor]},
-              {applications,[kernel,stdlib,mnesia,inets,lager]},
+              {applications,[kernel,stdlib,mnesia,inets]},
               {mod,{ekka_app,[]}}]}.

--- a/src/ekka.erl
+++ b/src/ekka.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.
@@ -31,13 +31,18 @@
 -export([is_aliving/1, is_running/2]).
 
 %% Cluster API
+-export([cluster_name/0]).
 -export([join/1, leave/0, force_leave/1]).
 
 %% Membership
--export([local_member/0, members/0, is_member/1, nodelist/0, status/0]).
+-export([nodelist/0, nodelist/1]).
+-export([local_member/0, members/0, is_member/1, status/0]).
 
 %% Monitor membership events
 -export([monitor/1, unmonitor/1]).
+
+%% Locker API
+-export([lock/1, lock/2, lock/3, unlock/1, unlock/2]).
 
 %%--------------------------------------------------------------------
 %% Start/Stop
@@ -84,7 +89,8 @@ autocluster(App, Fun) ->
             spawn(fun() ->
                     group_leader(whereis(init), self()),
                     wait_application_ready(App, 5),
-                    try ekka_autocluster:discover_and_join(Fun)
+                    try
+                        ekka_autocluster:discover_and_join(Fun)
                     catch
                         _:Error -> lager:error("Autocluster exception: ~p", [Error])
                     end,
@@ -122,10 +128,13 @@ local_member() ->
 is_member(Node) ->
     ekka_membership:is_member(Node).
 
-%% Node List
+%% Node list
 -spec(nodelist() -> list(node())).
 nodelist() ->
     ekka_membership:nodelist().
+
+nodelist(Status) ->
+    ekka_membership:nodelist(Status).
 
 %% Status of the cluster
 status() ->
@@ -148,6 +157,10 @@ is_running(Node, App) ->
 %%--------------------------------------------------------------------
 %% Cluster API
 %%--------------------------------------------------------------------
+
+-spec(cluster_name() -> cluster()).
+cluster_name() ->
+    env(cluster_name, undefined).
 
 %% @doc Join the cluster
 -spec(join(node()) -> ok | ignore | {error, any()}).
@@ -175,4 +188,30 @@ monitor(membership) ->
 
 unmonitor(membership) ->
     ekka_membership:monitor(false).
+
+%%--------------------------------------------------------------------
+%% Locker API
+%%--------------------------------------------------------------------
+
+-spec(lock(ekka_locker:resource()) -> ekka_locker:lock_result()).
+lock(Resource) ->
+    ekka_locker:aquire(Resource).
+
+-spec(lock(ekka_locker:resource(), ekka_locker:lock_type())
+      -> ekka_locker:lock_result()).
+lock(Resource, Type) ->
+    ekka_locker:aquire(ekka_locker, Resource, Type).
+
+-spec(lock(ekka_locker:resource(), ekka_locker:lock_type(), ekka_locker:piggyback())
+      -> ekka_locker:lock_result()).
+lock(Resource, Type, Piggyback) ->
+    ekka_locker:aquire(ekka_locker, Resource, Type, Piggyback).
+
+-spec(unlock(ekka_locker:resource()) -> boolean()).
+unlock(Resource) ->
+    ekka_locker:release(Resource).
+
+-spec(unlock(ekka_locker:resource(), ekka_locker:lock_type()) -> boolean()).
+unlock(Resource, Type) ->
+    ekka_locker:release(ekka_locker, Resource, Type).
 

--- a/src/ekka.erl
+++ b/src/ekka.erl
@@ -188,11 +188,10 @@ lock(Resource, Type) ->
 lock(Resource, Type, Piggyback) ->
     ekka_locker:aquire(ekka_locker, Resource, Type, Piggyback).
 
--spec(unlock(ekka_locker:resource()) -> boolean()).
+-spec(unlock(ekka_locker:resource()) -> ekka_locker:lock_result()).
 unlock(Resource) ->
     ekka_locker:release(Resource).
 
--spec(unlock(ekka_locker:resource(), ekka_locker:lock_type()) -> boolean()).
+-spec(unlock(ekka_locker:resource(), ekka_locker:lock_type()) -> ekka_locker:lock_result()).
 unlock(Resource, Type) ->
     ekka_locker:release(ekka_locker, Resource, Type).
-

--- a/src/ekka_app.erl
+++ b/src/ekka_app.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_autoclean.erl
+++ b/src/ekka_autoclean.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_autocluster.erl
+++ b/src/ekka_autocluster.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_autocluster.erl
+++ b/src/ekka_autocluster.erl
@@ -18,17 +18,65 @@
 
 -include("ekka.hrl").
 
--export([discover_and_join/1, unregister_node/0, aquire_lock/0, release_lock/0]).
+-export([enabled/0, run/2, unregister_node/0]).
+-export([aquire_lock/1, release_lock/1]).
 
+-define(RETRY_INTERVAL, 15000).
 -define(LOG(Level, Format, Args),
         lager:Level("Ekka(AutoCluster): " ++ Format, Args)).
 
--spec(discover_and_join(Fun :: fun() | mfa()) -> any()).
-discover_and_join(Fun) ->
+-spec(enabled() -> boolean()).
+enabled() ->
+    case ekka:env(cluster_discovery) of
+        {ok, {manual, _}} ->
+            false;
+        {ok, _}   -> true;
+        undefined -> false
+    end.
+
+-spec(run(atom(), fun() | mfa()) -> any()).
+run(App, Fun) ->
+    case aquire_lock(App) of
+        ok ->
+            spawn(fun() ->
+                      group_leader(whereis(init), self()),
+                      wait_application_ready(App, 10),
+                      try
+                          discover_and_join(),
+                          run_callback(Fun)
+                      catch
+                          _:Error ->
+                              lager:error("Autocluster error: ~p~n~p",
+                                          [Error, erlang:get_stacktrace()])
+                      after
+                          release_lock(App)
+                      end,
+                      %% Check if the node joined cluster?
+                      case ekka_mnesia:is_node_in_cluster() of
+                          true  -> ok;
+                          false -> ?LOG(info, "Run autocluster again...", []),
+                                   timer:sleep(?RETRY_INTERVAL),
+                                   run(App, Fun)
+                      end
+                  end);
+        failed -> ignore
+    end.
+
+wait_application_ready(_App, 0) ->
+    timeout;
+wait_application_ready(App, Retries) ->
+    case ekka_node:is_running(App) of
+        true  -> ok;
+        false -> timer:sleep(1000),
+                 wait_application_ready(App, Retries - 1)
+    end.
+
+-spec(discover_and_join() -> any()).
+discover_and_join() ->
     with_strategy(
       fun(Mod, Options) ->
         case Mod:lock(Options) of
-            ok -> 
+            ok ->
                 discover_and_join(Mod, Options),
                 log_error("Unlock", Mod:unlock(Options));
             ignore ->
@@ -37,27 +85,26 @@ discover_and_join(Fun) ->
             {error, Reason} ->
                 ?LOG(error, "AutoCluster stopped for lock error: ~p", [Reason])
         end
-      end),
-    run_callback(Fun).
+      end).
 
 -spec(unregister_node() -> ok).
 unregister_node() ->
     with_strategy(
       fun(Mod, Options) ->
-        log_error("Unregister", Mod:unregister(Options))
+          log_error("Unregister", Mod:unregister(Options))
       end).
 
--spec(aquire_lock() -> ok | failed).
-aquire_lock() ->
-    case application:get_env(ekka, autocluster_lock) of
+-spec(aquire_lock(atom()) -> ok | failed).
+aquire_lock(App) ->
+    case application:get_env(App, autocluster_lock) of
         undefined ->
-            application:set_env(ekka, autocluster_lock, true);
+            application:set_env(App, autocluster_lock, true);
         {ok, _} -> failed
     end.
 
--spec(release_lock() -> ok).
-release_lock() ->
-    application:unset_env(ekka, autocluster_lock).
+-spec(release_lock(atom()) -> ok).
+release_lock(App) ->
+    application:unset_env(App, autocluster_lock).
 
 with_strategy(Fun) ->
     case ekka:env(cluster_discovery) of
@@ -86,7 +133,6 @@ discover_and_join(Mod, Options) ->
 
 maybe_join([]) ->
     ignore;
-
 maybe_join(Nodes) ->
     case ekka_mnesia:is_node_in_cluster() of
         true  -> ignore;
@@ -95,17 +141,19 @@ maybe_join(Nodes) ->
 
 join_with(false) ->
     ignore;
+join_with(Node) when Node =:= node() ->
+    ignore;
 join_with(Node) ->
     ekka_cluster:join(Node).
 
-find_oldest_node([Node]) ->
-    Node;
+%%find_oldest_node([Node]) ->
+%%    Node;
 find_oldest_node(Nodes) ->
    case rpc:multicall(Nodes, ekka_membership, local_member, []) of
        {Members, []} ->
            Member = ekka_membership:oldest(Members), Member#member.node;
        {_Views, BadNodes} ->
-            ?LOG(error, "Bad nodes found: ~p", [BadNodes]), false
+           ?LOG(error, "Bad nodes found: ~p", [BadNodes]), false
    end.
 
 run_callback(Fun) when is_function(Fun) ->

--- a/src/ekka_autocluster.erl
+++ b/src/ekka_autocluster.erl
@@ -46,8 +46,7 @@ run(App, Fun) ->
                           run_callback(Fun)
                       catch
                           _:Error ->
-                              lager:error("Autocluster error: ~p~n~p",
-                                          [Error, erlang:get_stacktrace()])
+                              ?LOG(error, "Discover error: ~p~n~p", [Error, erlang:get_stacktrace()])
                       after
                           release_lock(App)
                       end,
@@ -146,14 +145,19 @@ join_with(Node) when Node =:= node() ->
 join_with(Node) ->
     ekka_cluster:join(Node).
 
-%%find_oldest_node([Node]) ->
-%%    Node;
+find_oldest_node([Node]) ->
+    Node;
 find_oldest_node(Nodes) ->
-   case rpc:multicall(Nodes, ekka_membership, local_member, []) of
-       {Members, []} ->
-           Member = ekka_membership:oldest(Members), Member#member.node;
-       {_Views, BadNodes} ->
-           ?LOG(error, "Bad nodes found: ~p", [BadNodes]), false
+    case rpc:multicall(Nodes, ekka_membership, local_member, []) of
+        {ResL, []} ->
+            case [M || M <- ResL, is_record(M, member)] of
+                [] -> ?LOG(error, "Bad members found on nodes ~p: ~p", [Nodes, ResL]),
+                      false;
+                Members ->
+                    (ekka_membership:oldest(Members))#member.node
+            end;
+        {ResL, BadNodes} ->
+            ?LOG(error, "Bad nodes found: ~p, ResL: ", [BadNodes, ResL]), false
    end.
 
 run_callback(Fun) when is_function(Fun) ->

--- a/src/ekka_autoheal.erl
+++ b/src/ekka_autoheal.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_boot.erl
+++ b/src/ekka_boot.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_boot.erl
+++ b/src/ekka_boot.erl
@@ -20,7 +20,7 @@
 
 %% only {F, Args}...
 apply_module_attributes(Name) ->
-    [{Module, [apply(Module, F, Args) || {F, Args} <- Attrs]} || 
+    [{Module, [apply(Module, F, Args) || {F, Args} <- Attrs]} ||
         {_App, Module, Attrs} <- all_module_attributes(Name)].
 
 %% Copy from rabbit_misc.erl
@@ -40,7 +40,6 @@ all_module_attributes(Name) ->
               end
       end, [], Targets).
 
-%% Copy from rabbit_misc.erl
 module_attributes(Module) ->
     case catch Module:module_info(attributes) of
         {'EXIT', {undef, [{Module, module_info, [attributes], []} | _]}} ->

--- a/src/ekka_cluster.erl
+++ b/src/ekka_cluster.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_cluster_dns.erl
+++ b/src/ekka_cluster_dns.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_cluster_etcd.erl
+++ b/src/ekka_cluster_etcd.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_cluster_k8s.erl
+++ b/src/ekka_cluster_k8s.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_cluster_mcast.erl
+++ b/src/ekka_cluster_mcast.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 
 handshake(Cookie) ->
-    {handshake, node(), ekka:env(cluster_name, ekka), Cookie}.
+    {handshake, node(), ekka:env(cluster_name, undefined), Cookie}.
 
 udp_open([], _Options) ->
     {error, eaddrinuse};

--- a/src/ekka_cluster_mcast.erl
+++ b/src/ekka_cluster_mcast.erl
@@ -60,13 +60,13 @@ discover(Options) ->
 
 lock(_Options) ->
     ignore.
-    
+
 unlock(_Options) ->
     ignore.
 
 register(_Options) ->
     ignore.
-    
+
 unregister(_Options) ->
     ignore.
 
@@ -166,7 +166,7 @@ handshake(Cookie) ->
 
 udp_open([], _Options) ->
     {error, eaddrinuse};
-    
+
 udp_open([Port|Ports], Options) ->
     case gen_udp:open(Port, [binary, {active, 10}, {reuseaddr, true} | Options]) of
         {ok, Sock} ->

--- a/src/ekka_cluster_mcast.erl
+++ b/src/ekka_cluster_mcast.erl
@@ -101,9 +101,10 @@ init(Options) ->
             {stop, Error}
     end.
 
-handle_call(discover, From, State = #state{sock = Sock, addr = Addr,ports = Ports, cookie = Cookie}) ->
+handle_call(discover, From, State = #state{sock = Sock, addr = Addr,
+                                           ports = Ports, cookie = Cookie}) ->
     lists:foreach(fun(Port) ->
-                    udp_send(Sock, Addr, Port, handshake(Cookie))
+                      udp_send(Sock, Addr, Port, ping(Cookie))
                   end, Ports),
     erlang:send_after(3000, self(), {reply, discover, From}),
     {noreply, State};
@@ -118,26 +119,28 @@ handle_cast(Msg, State) ->
 
 handle_info({reply, discover, From}, State = #state{seen = Seen}) ->
     gen_server:reply(From, {ok, [node() | Seen]}),
-    {noreply, State#state{seen = []}};
+    {noreply, State#state{seen = []}, hibernate};
 
-handle_info({udp, Sock, Ip, InPort, Data}, State = #state{sock = Sock, cookie = Cookie,seen = Seen}) ->
+handle_info({udp, Sock, Ip, InPort, Data},
+            State = #state{sock = Sock, cookie = Cookie, seen = Seen}) ->
+    io:format("Mcast Handshake: ~p~n", [binary_to_term(Data)]),
     inet:setopts(Sock, [{active, 1}]),
     Cluster = ekka:env(cluster_name, ekka),
     {noreply, try binary_to_term(Data) of
-                  {handshake, Node, _Cluster, _Cookie} when Node =:= node() ->
+                  {ping, Node, _Cluster, _Cookie} when Node =:= node() ->
                       State;
-                  {handshake, Node, Cluster, Cookie} ->
-                      case lists:member(Node, Seen) of
-                          false -> udp_send(Sock, Ip, InPort, handshake(Cookie));
-                          true  -> ok
-                      end,
+                  {ping, Node, Cluster, Cookie} ->
+                      udp_send(Sock, Ip, InPort, pong(Cookie)),
                       State#state{seen = lists:usort([Node | Seen])};
-                  Handshake = {handshake, _Node, _Cluster, _Cookie} ->
-                       ?LOG(warning, "Unexpected ~p", [Handshake]),
+                  {pong, Node, _Cluster, _Cookie} when Node =:= node() ->
+                      State;
+                  {pong, Node, Cluster, Cookie} ->
+                      State#state{seen = lists:usort([Node | Seen])};
+                  Handshake = {_Type, _Node, _Cluster, _Cookie} ->
+                       ?LOG(error, "Bad handshake: ~p", [Handshake]),
                        State;
-                  Term ->
-                       ?LOG(error, "Unexpected term: ~p", [Term]),
-                       State
+                  Term -> ?LOG(error, "Bad term: ~p", [Term]),
+                          State
               catch
                   error:badarg ->
                       ?LOG(error, "Corrupt data: ~p", [Data]),
@@ -161,8 +164,12 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 
-handshake(Cookie) ->
-    {handshake, node(), ekka:env(cluster_name, undefined), Cookie}.
+ping(Cookie) -> handshake(ping, Cookie).
+
+pong(Cookie) -> handshake(pong, Cookie).
+
+handshake(Type, Cookie) ->
+    {Type, node(), ekka:env(cluster_name, undefined), Cookie}.
 
 udp_open([], _Options) ->
     {error, eaddrinuse};

--- a/src/ekka_cluster_mcast.erl
+++ b/src/ekka_cluster_mcast.erl
@@ -123,7 +123,7 @@ handle_info({reply, discover, From}, State = #state{seen = Seen}) ->
 
 handle_info({udp, Sock, Ip, InPort, Data},
             State = #state{sock = Sock, cookie = Cookie, seen = Seen}) ->
-    io:format("Mcast Handshake: ~p~n", [binary_to_term(Data)]),
+    %%io:format("Mcast Handshake: ~p~n", [binary_to_term(Data)]),
     inet:setopts(Sock, [{active, 1}]),
     Cluster = ekka:env(cluster_name, ekka),
     {noreply, try binary_to_term(Data) of

--- a/src/ekka_cluster_static.erl
+++ b/src/ekka_cluster_static.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_cluster_strategy.erl
+++ b/src/ekka_cluster_strategy.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_cluster_sup.erl
+++ b/src/ekka_cluster_sup.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_guid.erl
+++ b/src/ekka_guid.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_guid.erl
+++ b/src/ekka_guid.erl
@@ -17,10 +17,10 @@
 %% @doc Generate global unique id.
 %%
 %% --------------------------------------------------------
-%% |        Timestamp       |  NodeID + PID  |  Sequence  | 
+%% |        Timestamp       |  NodeID + PID  |  Sequence  |
 %% |<------- 64bits ------->|<--- 48bits --->|<- 16bits ->|
 %% --------------------------------------------------------
-%% 
+%%
 %% 1. Timestamp: erlang:system_time if Erlang >= R18, otherwise os:timestamp
 %% 2. NodeId:    encode node() to 2 bytes integer
 %% 3. Pid:       encode pid to 4 bytes integer

--- a/src/ekka_httpc.erl
+++ b/src/ekka_httpc.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_locker.erl
+++ b/src/ekka_locker.erl
@@ -175,7 +175,7 @@ release(Name, Resource) ->
 
 -spec(release(atom(), resource(), lock_type()) -> lock_result()).
 release(Name, Resource, local) ->
-    {release_lock(Name, lock_obj(Resource)), [node()]};
+    release_lock(Name, lock_obj(Resource));
 release(Name, Resource, leader) ->
     Leader = ekka_membership:leader(),
     case rpc:call(Leader, ?MODULE, release_lock, [Name, lock_obj(Resource)]) of

--- a/src/ekka_locker.erl
+++ b/src/ekka_locker.erl
@@ -1,0 +1,300 @@
+%%%===================================================================
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%===================================================================
+
+-module(ekka_locker).
+
+-behaviour(gen_server).
+
+-export([start_link/0, start_link/1, start_link/2]).
+
+%% for test cases
+-export([stop/0, stop/1]).
+
+-export([aquire/1, aquire/2, aquire/3, aquire/4]).
+-export([release/1, release/2, release/3]).
+
+%% for rpc call
+-export([aquire_lock/2, aquire_lock/3, release_lock/2]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-type(resource() :: term()).
+
+-type(lock_type() :: local | leader | quorum | all).
+
+-type(lock_result() :: {boolean, [node() | {node(), any()}]}).
+
+-type(piggyback() :: mfa()).
+
+-export_type([resource/0, lock_type/0, lock_result/0, piggyback/0]).
+
+-record(lock, {resource :: resource(),
+               owner    :: pid(),
+               counter  :: integer(),
+               created  :: erlang:timestamp()}).
+
+-record(lease, {expiry, timer}).
+
+-record(state, {locks, lease, monitors}).
+
+-define(SERVER, ?MODULE).
+
+%% 15 seconds by default
+-define(LEASE_TIME, 15000).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec(start_link() -> {ok, pid()} | ignore | {error, any()}).
+start_link() ->
+    start_link(?SERVER).
+
+-spec(start_link(atom()) -> {ok, pid()} | ignore | {error, any()}).
+start_link(Name) ->
+    start_link(Name, ?LEASE_TIME).
+
+-spec(start_link(atom(), pos_integer()) -> {ok, pid()} | ignore | {error, any()}).
+start_link(Name, LeaseTime) ->
+    gen_server:start_link({local, Name}, ?MODULE, [Name, LeaseTime], []).
+
+-spec(stop() -> ok).
+stop() ->
+    stop(?SERVER).
+
+-spec(stop(atom()) -> ok).
+stop(Name) ->
+    gen_server:call(Name, stop).
+
+-spec(aquire(resource()) -> {boolean(), [node()]}).
+aquire(Resource) ->
+    aquire(?SERVER, Resource).
+
+-spec(aquire(atom(), resource()) -> lock_result()).
+aquire(Name, Resource) when is_atom(Name) ->
+    aquire(Name, Resource, local).
+
+-spec(aquire(atom(), resource(), lock_type()) -> lock_result()).
+aquire(Name, Resource, Type) ->
+    aquire(Name, Resource, Type, undefined).
+
+-spec(aquire(atom(), resource(), lock_type(), piggyback()) -> lock_result()).
+aquire(Name, Resource, local, Piggyback) when is_atom(Name) ->
+    aquire_lock(Name, lock_obj(Resource), Piggyback);
+aquire(Name, Resource, leader, Piggyback) when is_atom(Name)->
+    Leader = ekka_membership:leader(),
+    case rpc:call(Leader, ?MODULE, aquire_lock,
+                  [Name, lock_obj(Resource), Piggyback]) of
+        Err = {badrpc, _Reason} ->
+            {false, [{Leader, Err}]};
+        Res -> Res
+    end;
+aquire(Name, Resource, quorum, Piggyback) when is_atom(Name) ->
+    aquire_locks(ekka_ring:find_nodes(Resource),
+                 Name, lock_obj(Resource), Piggyback);
+
+aquire(Name, Resource, all, Piggyback) when is_atom(Name) ->
+    aquire_locks(ekka_membership:nodelist(up),
+                 Name, lock_obj(Resource), Piggyback).
+
+aquire_locks(Nodes, Name, LockObj, Piggyback) ->
+    case lists:member(node(), Nodes)
+         andalso check_local(Name, LockObj) of
+        true ->
+            {ResL, _BadNodes}
+                = rpc:multicall(Nodes, ?MODULE, aquire_lock, [Name, LockObj, Piggyback]),
+            case merge_results(ResL) of
+                Res = {true, _}  -> Res;
+                Res = {false, _} ->
+                    rpc:multicall(Nodes, ?MODULE, release_lock, [Name, LockObj]),
+                    Res
+            end;
+        false ->
+            {false, [node()]}
+    end.
+
+aquire_lock(Name, LockObj, Piggyback) ->
+    {aquire_lock(Name, LockObj), [with_piggyback(node(), Piggyback)]}.
+
+aquire_lock(Name, LockObj = #lock{resource = Resource, owner = Owner}) ->
+    Pos = #lock.counter,
+    try ets:update_counter(Name, Resource, [{Pos, 0}, {Pos, 1, 1, 1}]) of
+        [0, 1] -> true;
+        [1, 1] ->
+            case ets:lookup(Name, Resource) of
+                [#lock{owner = Owner}] ->
+                    true;
+                _Other -> false
+            end
+    catch
+        error:badarg ->
+            ets:insert_new(Name, LockObj)
+    end.
+
+check_local(Name, #lock{resource = Resource, owner = Owner}) ->
+    case ets:lookup(Name, Resource) of
+        [#lock{owner = Owner}] ->
+            true;
+        [_Lock] -> false;
+        []      -> true
+    end.
+
+with_piggyback(Node, undefined) ->
+    Node;
+with_piggyback(Node, {M, F, Args}) ->
+    {Node, erlang:apply(M, F, Args)}.
+
+lock_obj(Resource) ->
+    #lock{resource = Resource,
+          owner    = self(),
+          counter  = 1,
+          created  = os:timestamp()}.
+
+-spec(release(resource()) -> lock_result()).
+release(Resource) ->
+    release(?SERVER, Resource).
+
+-spec(release(atom(), resource()) -> lock_result()).
+release(Name, Resource) ->
+    release(Name, Resource, local).
+
+-spec(release(atom(), resource(), lock_type()) -> lock_result()).
+release(Name, Resource, local) ->
+    {release_lock(Name, lock_obj(Resource)), [node()]};
+release(Name, Resource, leader) ->
+    Leader = ekka_membership:leader(),
+    case rpc:call(Leader, ?MODULE, release_lock, [Name, lock_obj(Resource)]) of
+        Err = {badrpc, _Reason} ->
+            {false, [{Leader, Err}]};
+        Res -> Res
+    end;
+release(Name, Resource, quorum) ->
+    release_locks(ekka_ring:find_nodes(Resource), Name, lock_obj(Resource));
+release(Name, Resource, all) ->
+    release_locks(ekka_membership:nodelist(up), Name, lock_obj(Resource)).
+
+release_locks(Nodes, Name, LockObj) ->
+    {ResL, _BadNodes} = rpc:multicall(Nodes, ?MODULE, release_lock, [Name, LockObj]),
+    merge_results(ResL).
+
+release_lock(Name, #lock{resource = Resource, owner = Owner}) ->
+    Res = case ets:lookup(Name, Resource) of
+              [Lock = #lock{owner = Owner}] ->
+                  ets:delete_object(Name, Lock);
+              [_Lock] -> false;
+              []      -> false
+          end,
+    {Res, [node()]}.
+
+merge_results(ResL) ->
+    merge_results(ResL, [], []).
+merge_results([], Succ, []) ->
+    {true, Succ};
+merge_results([], _, Failed) ->
+    {false, Failed};
+merge_results([{true, Res}|ResL], Succ, Failed) ->
+    merge_results(ResL, [Res|Succ], Failed);
+merge_results([{false, Res}|ResL], Succ, Failed) ->
+    merge_results(ResL, Succ, [Res|Failed]).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([Name, LeaseTime]) ->
+    Tab = ets:new(Name, [public, set, named_table, {keypos, 2},
+                         {read_concurrency, true}, {write_concurrency, true}]),
+    TRef = timer:send_interval(LeaseTime * 2, check_lease),
+    Lease = #lease{expiry = LeaseTime, timer = TRef},
+    {ok, #state{locks = Tab, lease = Lease, monitors = #{}}}.
+
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State};
+
+handle_call(_Request, _From, State) ->
+    {reply, ignore, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(check_lease, State = #state{locks = Tab, lease = Lease, monitors = Monitors}) ->
+    Monitors1 = lists:foldl(
+                  fun(#lock{resource = Resource, owner = Owner}, MonAcc) ->
+                      case maps:find(Owner, MonAcc) of
+                          {ok, Resources} ->
+                              maps:put(Owner, [Resource|Resources], MonAcc);
+                          error ->
+                              _MRef = erlang:monitor(process, Owner),
+                              maps:put(Owner, [Resource], MonAcc)
+                      end
+                  end, Monitors, check_lease(Tab, Lease, os:timestamp())),
+    {noreply, State#state{monitors = Monitors1}, hibernate};
+
+handle_info({'DOWN', _MRef, process, DownPid, _Reason},
+            State = #state{locks = Tab, monitors = Monitors}) ->
+    io:format("Lock owner DOWN: ~p~n", [DownPid]),
+    case maps:find(DownPid, Monitors) of
+        {ok, Resources} ->
+            lists:foreach(
+              fun(Resource) ->
+                  case ets:lookup(Tab, Resource) of
+                      [Lock = #lock{owner = OwnerPid}] when OwnerPid =:= DownPid ->
+                          ets:delete_object(Tab, Lock);
+                      _ -> ok
+                  end
+              end, Resources),
+            {noreply, State#state{monitors = maps:remove(DownPid, Monitors)}};
+        error ->
+            {noreply, State}
+    end;
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State = #state{lease = Lease}) ->
+    cancel_lease(Lease).
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+check_lease(Tab, #lease{expiry = Expiry}, Now) ->
+    check_lease(Tab, ets:first(Tab), Expiry, Now, []).
+
+check_lease(_Tab, '$end_of_table', _Expiry, _Now, Acc) ->
+    Acc;
+check_lease(Tab, Resource, Expiry, Now, Acc) ->
+    check_lease(Tab, ets:next(Tab, Resource), Expiry, Now,
+                case ets:lookup(Tab, Resource) of
+                    [Lock] ->
+                        case is_expired(Lock, Expiry, Now) of
+                            true  -> [Lock|Acc];
+                            false -> Acc
+                        end;
+                    [] -> Acc
+                end).
+
+is_expired(#lock{created = Created}, Expiry, Now) ->
+    (timer:now_diff(Now, Created) div 1000) > Expiry.
+
+cancel_lease(#lease{timer = TRef}) ->
+    timer:cancel(TRef).
+

--- a/src/ekka_locker_sup.erl
+++ b/src/ekka_locker_sup.erl
@@ -14,7 +14,7 @@
 %%% limitations under the License.
 %%%===================================================================
 
--module(ekka_sup).
+-module(ekka_locker_sup).
 
 -behaviour(supervisor).
 
@@ -26,11 +26,7 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    Childs = [child(ekka_cluster_sup, supervisor),
-              child(ekka_membership, worker),
-              child(ekka_node_monitor, worker),
-              child(ekka_locker_sup, supervisor)],
-    {ok, {{one_for_all, 0, 3600}, Childs}}.
+    Locker = {ekka_locker, {ekka_locker, start_link, []},
+              permanent, 2000, worker, [ekka_locker]},
+    {ok, {{one_for_one, 100, 3600}, [Locker]}}.
 
-child(Mod, Type) ->
-    {Mod, {Mod, start_link, []}, permanent, 5000, Type, [Mod]}.

--- a/src/ekka_membership.erl
+++ b/src/ekka_membership.erl
@@ -175,7 +175,7 @@ call(Req) ->
 %%%===================================================================
 
 init([]) ->
-    ets:new(membership, [ordered_set, protected, named_table, {keypos, 2}]),
+    _ = ets:new(membership, [ordered_set, protected, named_table, {keypos, 2}]),
     IsMnesiaRunning = case lists:member(node(), ekka_mnesia:running_nodes()) of
                           true  -> running;
                           false -> stopped
@@ -183,7 +183,7 @@ init([]) ->
     LocalMember = with_hash(#member{node = node(), guid = ekka_guid:gen(),
                                     status = up, mnesia = IsMnesiaRunning,
                                     ltime = erlang:timestamp()}),
-    ets:insert(membership, LocalMember),
+    true = ets:insert(membership, LocalMember),
     lists:foreach(fun(Node) ->
                       spawn(?MODULE, ping, [Node, LocalMember])
                   end, ekka_mnesia:cluster_nodes(all) -- [node()]),

--- a/src/ekka_mnesia.erl
+++ b/src/ekka_mnesia.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_mnesia.erl
+++ b/src/ekka_mnesia.erl
@@ -159,7 +159,7 @@ cluster_status() ->
 -spec(cluster_status(node()) -> running | stopped | false).
 cluster_status(Node) ->
     case is_node_in_cluster(Node) of
-        true  -> 
+        true  ->
             case lists:member(Node, running_nodes()) of
                 true  -> running;
                 false -> stopped
@@ -279,7 +279,7 @@ wait_for(start) ->
         stopping -> {error, mnesia_unexpectedly_stopping};
         starting -> timer:sleep(1000), wait_for(start)
     end;
- 
+
 wait_for(stop) ->
     case mnesia:system_info(is_running) of
         no       -> ok;

--- a/src/ekka_node.erl
+++ b/src/ekka_node.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_node_monitor.erl
+++ b/src/ekka_node_monitor.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_node_ttl.erl
+++ b/src/ekka_node_ttl.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2018 EMQ Enterprise, Inc. All Rights Reserved.
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/src/ekka_ring.erl
+++ b/src/ekka_ring.erl
@@ -48,7 +48,7 @@ find_nodes(Key) ->
 find_nodes(Key, Count) ->
     find_nodes(Key, Count, ring()).
 
-find_nodes(Key, Count, Ring) -> 
+find_nodes(Key, Count, Ring) ->
     [N || #member{node = N} <- next_members(phash(Key), Count, Ring)].
 
 next_members(_Hash, Count, Ring) when Count >= length(Ring) ->

--- a/src/ekka_ring.erl
+++ b/src/ekka_ring.erl
@@ -1,0 +1,88 @@
+%%%===================================================================
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%===================================================================
+
+-module(ekka_ring).
+
+-include("ekka.hrl").
+
+-export([find_node/1, find_nodes/1, find_nodes/2]).
+
+-type(key() :: term()).
+
+%% trunc(math:pow(2, 32) - 1))
+-define(BASE, 4294967295).
+
+-spec(find_node(key()) -> node()).
+find_node(Key) ->
+    (next_member(phash(Key), ring()))#member.node.
+
+next_member(Hash, Ring = [Head|_]) ->
+    next_member(Hash, Head, Ring).
+
+next_member(_Hash, Head, []) ->
+    Head;
+next_member(Hash, _Head, [M = #member{hash = MHash}|_])
+    when MHash >= Hash ->
+    M;
+next_member(Hash, Head, [_|Ring]) ->
+    next_member(Hash, Head, Ring).
+
+find_nodes(Key) ->
+    Ring = ring(),
+    Count = min(quorum(Ring), length(Ring)),
+    find_nodes(Key, Count, Ring).
+
+find_nodes(Key, Count) ->
+    find_nodes(Key, Count, ring()).
+
+find_nodes(Key, Count, Ring) -> 
+    [N || #member{node = N} <- next_members(phash(Key), Count, Ring)].
+
+next_members(_Hash, Count, Ring) when Count >= length(Ring) ->
+    Ring;
+next_members(Hash, Count, Ring) ->
+    {Left, Right} = split_ring(Hash, Ring),
+    case length(Right) >= Count of
+        true ->
+            lists:sublist(Right, 1, Count);
+        false ->
+            lists:append(Right, lists:sublist(Left, 1, Count - length(Right)))
+    end.
+
+split_ring(Hash, Ring) ->
+    split_ring(Hash, Ring, [], []).
+
+split_ring(_Hash, [], Left, Right) ->
+    {lists:reverse(Left), lists:reverse(Right)};
+
+split_ring(Hash, [M = #member{hash = MHash}|Ring], Left, Right) ->
+    case Hash =< MHash of
+        true  -> split_ring(Hash, Ring, Left, [M|Right]);
+        false -> split_ring(Hash, Ring, [M|Left], Right)
+    end.
+
+quorum(Ring) ->
+    case length(Ring) div 2 + 1 of
+        N when N > 3 -> 3;
+        N -> N
+    end.
+
+ring() ->
+    lists:keysort(#member.hash, ekka_membership:members(up)).
+
+phash(Key) ->
+    erlang:phash2(Key, ?BASE).
+

--- a/src/ekka_sup.erl
+++ b/src/ekka_sup.erl
@@ -32,5 +32,19 @@ init([]) ->
               child(ekka_locker_sup, supervisor)],
     {ok, {{one_for_all, 0, 3600}, Childs}}.
 
-child(Mod, Type) ->
-    {Mod, {Mod, start_link, []}, permanent, 5000, Type, [Mod]}.
+child(Mod, worker) ->
+    #{id       => Mod,
+      start    => {Mod, start_link, []},
+      restart  => permanent,
+      shutdown => 5000,
+      type     => worker,
+      modules  => [Mod]};
+
+child(Mod, supervisor) ->
+     #{id       => Mod,
+       start    => {Mod, start_link, []},
+       restart  => permanent,
+       shutdown => infinity,
+       type     => supervisor,
+       modules  => [Mod]}.
+

--- a/test/ekka_SUITE.erl
+++ b/test/ekka_SUITE.erl
@@ -1,18 +1,18 @@
-%%--------------------------------------------------------------------
-%% Copyright (c) 2017 EMQ Enterprise, Inc. (http://emqtt.io)
-%%
-%% Licensed under the Apache License, Version 2.0 (the "License");
-%% you may not use this file except in compliance with the License.
-%% You may obtain a copy of the License at
-%%
-%%     http://www.apache.org/licenses/LICENSE-2.0
-%%
-%% Unless required by applicable law or agreed to in writing, software
-%% distributed under the License is distributed on an "AS IS" BASIS,
-%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-%% See the License for the specific language governing permissions and
-%% limitations under the License.
-%%--------------------------------------------------------------------
+%%%===================================================================
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%===================================================================
 
 -module(ekka_SUITE).
 

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2017 EMQ Enterprise, Inc. (http://emqtt.io)
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -69,8 +69,8 @@ strategy_options(static) ->
     [{seeds, ?NODES}];
 
 strategy_options(mcast) ->
-    [{addr, {239,192,0,1}}, {ports, [4369,4370,4371]},
-     {iface, {0,0,0,0}}, {ttl,1}, {loop,true}];
+    [{addr, {239,192,0,1}}, {ports, [4369,4370,4371,4372,4373]},
+     {iface, {0,0,0,0}}, {ttl,255}, {loop,true}];
 
 strategy_options(dns) ->
     [{name,"localhost"},{app,"ekka_ct"}].

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -35,17 +35,16 @@ groups() ->
       t_autocluster_mcast,
       t_autocluster_dns,
       t_autocluster_etcd,
-      t_autocluster_k8s
-     ]}].
+      t_autocluster_k8s]}].
 
 init_per_testcase(t_autocluster_static, Config) ->
     configure_strategy(static),
-    start_ekka_and_cluster(), 
+    start_ekka_and_cluster(),
     Config;
 
 init_per_testcase(t_autocluster_mcast, Config) ->
     configure_strategy(mcast),
-    start_ekka_and_cluster(), 
+    start_ekka_and_cluster(),
     Config;
 
 init_per_testcase(t_autocluster_dns, Config) ->
@@ -86,10 +85,10 @@ t_autocluster_mcast(Config) ->
 t_autocluster_dns(Config) ->
     t_autocluster(dns, Config).
 
-t_autocluster_etcd(Config) ->
+t_autocluster_etcd(_Config) ->
     ok.
 
-t_autocluster_k8s(Config) ->
+t_autocluster_k8s(_Config) ->
     ok.
 
 t_autocluster(Strategy, _Config) ->
@@ -104,6 +103,8 @@ t_autocluster(Strategy, _Config) ->
 start_and_cluster(Strategy, Name) ->
     Node = ekka_test:start_slave(ekka, Name),
     ekka_test:wait_running(Node),
+    rpc:call(Node, application, set_env,
+             [ekka, cluster_name, ekka]),
     rpc:call(Node, application, set_env,
              [ekka, cluster_discovery, {Strategy, strategy_options(Strategy)}]),
     true = ekka:is_running(Node, ekka),

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -17,11 +17,10 @@
 -module(ekka_autocluster_SUITE).
 
 -compile(export_all).
+-compile(nowarn_export_all).
 
 -include("ekka.hrl").
-
 -include_lib("eunit/include/eunit.hrl").
-
 -include_lib("common_test/include/ct.hrl").
 
 -define(NODES, ['ekka_ct@127.0.0.1', 'ekka_ct1@127.0.0.1', 'ekka_ct2@127.0.0.1']).

--- a/test/ekka_lib_SUITE.erl
+++ b/test/ekka_lib_SUITE.erl
@@ -19,6 +19,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
+-compile(nowarn_export_all).
 
 all() -> [{group, node}].
 

--- a/test/ekka_lib_SUITE.erl
+++ b/test/ekka_lib_SUITE.erl
@@ -1,18 +1,18 @@
-%%--------------------------------------------------------------------
-%% Copyright (c) 2017 EMQ Enterprise, Inc. (http://emqtt.io)
-%%
-%% Licensed under the Apache License, Version 2.0 (the "License");
-%% you may not use this file except in compliance with the License.
-%% You may obtain a copy of the License at
-%%
-%%     http://www.apache.org/licenses/LICENSE-2.0
-%%
-%% Unless required by applicable law or agreed to in writing, software
-%% distributed under the License is distributed on an "AS IS" BASIS,
-%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-%% See the License for the specific language governing permissions and
-%% limitations under the License.
-%%--------------------------------------------------------------------
+%%%===================================================================
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%===================================================================
 
 -module(ekka_lib_SUITE).
 

--- a/test/ekka_locker_SUITE.erl
+++ b/test/ekka_locker_SUITE.erl
@@ -19,6 +19,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
+-compile(nowarn_export_all).
 
 all() ->
     [{group, locker}].

--- a/test/ekka_test.erl
+++ b/test/ekka_test.erl
@@ -17,6 +17,7 @@
 -module(ekka_test).
 
 -compile(export_all).
+-compile(nowarn_export_all).
 
 start_slave(node, Node) ->
     {ok, N} = slave:start(host(), Node, ebin_path()),

--- a/test/ekka_test.erl
+++ b/test/ekka_test.erl
@@ -1,3 +1,18 @@
+%%%===================================================================
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%===================================================================
 
 -module(ekka_test).
 

--- a/test/ekka_test_table.erl
+++ b/test/ekka_test_table.erl
@@ -1,5 +1,5 @@
 %%%===================================================================
-%%% Copyright (c) 2013-2017 EMQ Enterprise, Inc. (http://emqtt.io)
+%%% Copyright (c) 2013-2018 EMQ Inc. All Rights Reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.


### PR DESCRIPTION
- emqx30 branch of ekka supports retry autoclustering, an importantant feature to have if we are running emqx in k8s infrastructure.
- Cherry picked the commits from emqx30 branch to a base branch emq24, excluding the commits that introduced breaking changes (OTP21 and autocluster/1)
- Created Tag v0.3.1