### PR TITLE
Ekka cluster without epmd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,25 @@ Ekka implements a simple distributed lock service in 0.3 release.  The Lock APIs
 
 TODO:
 
+## Cluster without epmd
+
+The ekka 0.6.0 release implements erlang distribiton without epmd.
+
+See: http://erlang.org/pipermail/erlang-questions/2015-December/087013.html
+
+For example:
+
+```
+## Dist port: 4370
+erl -pa ebin -pa deps/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node1@127.0.0.1 -s ekka
+## Dist port: 4371
+erl -pa ebin -pa deps/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node2@127.0.0.1 -s ekka
+## Dist port: 4372
+erl -pa ebin -pa deps/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node3@127.0.0.1  -s ekka
+```
+
+The erlang distribution port can be tuned by ekka `inet_dist_base_port` env. The default port is 4370.
+
 ## License
 
 Apache License Version 2.0

--- a/README.md
+++ b/README.md
@@ -265,11 +265,11 @@ For example:
 
 ```
 ## Dist port: 4370
-erl -pa ebin -pa deps/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node1@127.0.0.1 -s ekka
+erl -pa ebin -pa _build/default/lib/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node1@127.0.0.1 -s ekka
 ## Dist port: 4371
-erl -pa ebin -pa deps/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node2@127.0.0.1 -s ekka
+erl -pa ebin -pa _build/default/lib/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node2@127.0.0.1 -s ekka
 ## Dist port: 4372
-erl -pa ebin -pa deps/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node3@127.0.0.1  -s ekka
+erl -pa ebin -pa _build/default/lib/*/ebin -proto_dist ekka -start_epmd false -epmd_module ekka_epmd -name node3@127.0.0.1  -s ekka
 ```
 
 The erlang distribution port can be tuned by ekka `inet_dist_base_port` env. The default port is 4370.

--- a/etc/ekka.conf.example
+++ b/etc/ekka.conf.example
@@ -45,6 +45,16 @@ cluster.autoheal = on
 ## Default: 5m
 cluster.autoclean = 5m
 
+## Specify the erlang distributed protocol for the cluster.
+##
+## Value: Enum
+##  - inet_tcp: the default; handles TCP streams with IPv4 addressing.
+##  - inet6_tcp: handles TCP with IPv6 addressing.
+##  - inet_tls: using TLS for Erlang Distribution.
+##
+## vm.args: -proto_dist inet_tcp
+cluster.proto_dist = inet_tcp
+
 ##--------------------------------------------------------------------
 ## Cluster using static node list.
 

--- a/etc/ekka.config.example
+++ b/etc/ekka.config.example
@@ -2,6 +2,7 @@
   {cluster_name, ekka},
   {cluster_autoheal, true},
   {cluster_autoclean, 60000},
+  {proto_dist, inet_tcp},
 
 %% Clustering with static node list
 %% {cluster_discovery, {static, [

--- a/priv/ekka.schema
+++ b/priv/ekka.schema
@@ -31,6 +31,12 @@
   {default, off}
 ]}.
 
+%% @doc The erlang distributed protocol for the cluster
+{mapping, "cluster.proto_dist", "ekka.proto_dist", [
+  {default, inet_tcp},
+  {datatype, {enum, [inet_tcp, inet6_tcp, inet_tls]}}
+]}.
+
 %%--------------------------------------------------------------------
 %% Cluster by static node list
 

--- a/src/ekka.erl
+++ b/src/ekka.erl
@@ -199,3 +199,4 @@ unlock(Resource) ->
 -spec(unlock(ekka_locker:resource(), ekka_locker:lock_type()) -> ekka_locker:lock_result()).
 unlock(Resource, Type) ->
     ekka_locker:release(ekka_locker, Resource, Type).
+

--- a/src/ekka_dist.erl
+++ b/src/ekka_dist.erl
@@ -1,0 +1,91 @@
+%% Copyright (c) 2018 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(ekka_dist).
+
+-export([listen/1,
+         select/1,
+         accept/1,
+         accept_connection/5,
+         setup/5,
+         close/1,
+         childspecs/0]).
+
+-export([port/1]).
+
+-define(DEFAULT_PORT, 4370).
+
+listen(Name) ->
+    %% Here we figure out what port we want to listen on.
+    Port = port(Name),
+
+    %% Set both "min" and "max" variables, to force the port number to
+    %% this one.
+    ok = application:set_env(kernel, inet_dist_listen_min, Port),
+    ok = application:set_env(kernel, inet_dist_listen_max, Port),
+
+    %% Finally run the real function!
+    with_module(fun(M) -> M:listen(Name) end).
+
+select(Node) ->
+    with_module(fun(M) -> M:select(Node) end).
+
+accept(Listen) ->
+    with_module(fun(M) -> M:accept(Listen) end).
+
+accept_connection(AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
+    with_module(fun(M) ->
+                    M:accept_connection(AcceptPid, Socket, MyNode, Allowed, SetupTime)
+                end).
+
+setup(Node, Type, MyNode, LongOrShortNames, SetupTime) ->
+    with_module(fun(M) ->
+                    M:setup(Node, Type, MyNode, LongOrShortNames, SetupTime)
+                end).
+
+close(Listen) ->
+    with_module(fun(M) -> M:close(Listen) end).
+
+childspecs() ->
+    with_module(fun(M) -> M:childspecs() end).
+
+with_module(Fun) ->
+    Proto = application:get_env(ekka, proto_dist, inet_tcp),
+    Fun(list_to_existing_atom(atom_to_list(Proto) ++ "_dist")).
+
+%% @doc Figure out dist port from node's name.
+-spec(port(node() | string()) -> inet:port_number()).
+port(Name) when is_atom(Name) ->
+    port(atom_to_list(Name));
+port(Name) when is_list(Name) ->
+    %% Figure out the base port.  If not specified using the
+    %% inet_dist_base_port kernel environment variable, default to
+    %% 4370, one above the epmd port.
+    BasePort = application:get_env(kernel, inet_dist_base_port, ?DEFAULT_PORT),
+
+    %% Now, figure out our "offset" on top of the base port.  The
+    %% offset is the integer just to the left of the @ sign in our node
+    %% name.  If there is no such number, the offset is 0.
+    %%
+    %% Also handle the case when no hostname was specified.
+    NodeName = re:replace(Name, "@.*$", ""),
+    Offset =
+        case re:run(NodeName, "[0-9]+$", [{capture, first, list}]) of
+            nomatch ->
+                0;
+            {match, [OffsetAsString]} ->
+                list_to_integer(OffsetAsString)
+        end,
+    BasePort + Offset.
+

--- a/src/ekka_epmd.erl
+++ b/src/ekka_epmd.erl
@@ -1,0 +1,65 @@
+%% Copyright (c) 2018 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc https://www.erlang-solutions.com/blog/erlang-and-elixir-distribution-without-epmd.html
+
+-module(ekka_epmd).
+
+-include("ekka.hrl").
+
+%% epmd_module callbacks
+-export([start_link/0]).
+-export([port_please/2, port_please/3]).
+-export([names/0, names/1]).
+-export([register_node/2, register_node/3]).
+%% -export([address_please/3]).
+
+%% The supervisor module erl_distribution tries to add us as a child
+%% process.  We don't need a child process, so return 'ignore'.
+start_link() ->
+    ignore.
+
+register_node(_Name, _Port) ->
+    %% This is where we would connect to epmd and tell it which port
+    %% we're listening on, but since we're epmd-less, we don't do that.
+
+    %% Need to return a "creation" number between 1 and 3.
+    Creation = rand:uniform(3),
+    {ok, Creation}.
+
+%% As of Erlang/OTP 19.1, register_node/3 is used instead of
+%% register_node/2, passing along the address family, 'inet_tcp' or
+%% 'inet6_tcp'.  This makes no difference for our purposes.
+register_node(Name, Port, _Family) ->
+    register_node(Name, Port).
+
+port_please(Name, _IP) ->
+    Port = ekka_dist:port(Name),
+    %% The distribution protocol version number has been 5 ever since
+    %% Erlang/OTP R6.
+    Version = 5,
+    {port, Port, Version}.
+
+port_please(Name, IP, _Timeout) ->
+    port_please(Name, IP).
+
+names() ->
+    {ok, H} = inet:gethostname(),
+    names(H).
+
+names(_Hostname) ->
+    %% Since we don't have epmd, we don't really know what other nodes
+    %% there are.
+    {error, address}.
+


### PR DESCRIPTION
- Add ekka_epmd, ekka_dist modules.
- Add 'cluster.proto_dist' config.

See:
http://erlang.org/pipermail/erlang-questions/2015-December/087013.html
https://www.erlang-solutions.com/blog/erlang-and-elixir-distribution-without-epmd.html