### PR TITLE
Support static node name for k8s cluster discovery

### DIFF
--- a/etc/ekka.conf.example
+++ b/etc/ekka.conf.example
@@ -156,11 +156,16 @@ cluster.autoclean = 5m
 
 ## The address type is used to extract host from k8s service.
 ##
-## Value: ip | dns
+## Value: ip | dns | hostname
 ## cluster.k8s.address_type = ip
 
 ## The app name helps build 'node.name'.
 ##
 ## Value: String
 ## cluster.k8s.app_name = ekka
+
+## The suffix added to hostname get from k8s service, only valid if cluster.k8s.address_type set to hostname
+##
+## Value: String
+## cluster.k8s.hostname_suffix =
 

--- a/priv/ekka.schema
+++ b/priv/ekka.schema
@@ -144,7 +144,8 @@
 ]}.
 
 {mapping, "cluster.k8s.hostname_suffix", "ekka.cluster_discovery", [
-  {datatype, string}
+  {datatype, string},
+  {default, ""}
 ]}.
 
 {translation, "ekka.cluster_discovery", fun(Conf) ->
@@ -184,7 +185,7 @@
                   {address_type, cuttlefish:conf_get("cluster.k8s.address_type", Conf, ip)},
                   {app_name, cuttlefish:conf_get("cluster.k8s.app_name", Conf)},
                   {namespace, cuttlefish:conf_get("cluster.k8s.namespace", Conf)},
-                   {hostname_suffix, cuttlefish:conf_get("cluster.k8s.hostname_suffix", Conf)}];
+                   {hostname_suffix, cuttlefish:conf_get("cluster.k8s.hostname_suffix", Conf, "")}];
                (manual) ->
                  [ ]
             end,

--- a/priv/ekka.schema
+++ b/priv/ekka.schema
@@ -132,7 +132,7 @@
 ]}.
 
 {mapping, "cluster.k8s.address_type", "ekka.cluster_discovery", [
-  {datatype, {enum, [ip, dns]}}
+  {datatype, {enum, [ip, dns, hostname]}}
 ]}.
 
 {mapping, "cluster.k8s.app_name", "ekka.cluster_discovery", [
@@ -140,6 +140,10 @@
 ]}.
 
 {mapping, "cluster.k8s.namespace", "ekka.cluster_discovery", [
+  {datatype, string}
+]}.
+
+{mapping, "cluster.k8s.hostname_suffix", "ekka.cluster_discovery", [
   {datatype, string}
 ]}.
 
@@ -179,7 +183,8 @@
                   {service_name, cuttlefish:conf_get("cluster.k8s.service_name", Conf)},
                   {address_type, cuttlefish:conf_get("cluster.k8s.address_type", Conf, ip)},
                   {app_name, cuttlefish:conf_get("cluster.k8s.app_name", Conf)},
-                  {namespace, cuttlefish:conf_get("cluster.k8s.namespace", Conf)}];
+                  {namespace, cuttlefish:conf_get("cluster.k8s.namespace", Conf)},
+                   {hostname_suffix, cuttlefish:conf_get("cluster.k8s.hostname_suffix", Conf)}];
                (manual) ->
                  [ ]
             end,

--- a/src/ekka_cluster_k8s.erl
+++ b/src/ekka_cluster_k8s.erl
@@ -30,83 +30,83 @@
 %%--------------------------------------------------------------------
 
 discover(Options) ->
-    Server = get_value(apiserver, Options),
-    Service = get_value(service_name, Options),
-    App = get_value(app_name, Options, "ekka"),
-    AddrType = get_value(address_type, Options, ip),
-    Namespace = get_value(namespace, Options, "default"),
-    NodeNameSuffix = case AddrType of
-                         hostname -> get_value(hostname_suffix, Options, "");
-                         _ -> ""
-                     end,
-    case k8s_service_get(Server, Service, Namespace) of
-        {ok, Response} ->
-            Addresses = extract_addresses(AddrType, Response, Namespace),
-            {ok, [node_name(App, Addr, NodeNameSuffix) || Addr <- Addresses]};
-        {error, Reason} ->
-            {error, Reason}
-    end.
+  Server = get_value(apiserver, Options),
+  Service = get_value(service_name, Options),
+  App = get_value(app_name, Options, "ekka"),
+  AddrType = get_value(address_type, Options, ip),
+  Namespace = get_value(namespace, Options, "default"),
+  Suffix = get_value(hostname_suffix, Options, ""),
+  case k8s_service_get(Server, Service, Namespace) of
+    {ok, Response} ->
+      Addresses = extract_addresses(AddrType, Response, Namespace),
+      {ok, [node_name(App, Addr, AddrType, Suffix) || Addr <- Addresses]};
+    {error, Reason} ->
+      {error, Reason}
+  end.
 
-node_name(App, Addr, Suffix) ->
-    list_to_atom(App ++ "@" ++ binary_to_list(Addr) ++ Suffix).
+node_name(App, Addr, hostname, Suffix) when length(Suffix) > 0 ->
+  list_to_atom(App ++ "@" ++ binary_to_list(Addr) ++ Suffix);
+
+node_name(App, Addr, _, _) ->
+  list_to_atom(App ++ "@" ++ binary_to_list(Addr)).
 
 lock(_Options) ->
-    ignore.
+  ignore.
 
 unlock(_Options) ->
-    ignore.
+  ignore.
 
 register(_Options) ->
-    ignore.
+  ignore.
 
 unregister(_Options) ->
-    ignore.
+  ignore.
 
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
 
 k8s_service_get(Server, Service, Namespace) ->
-    Headers = [{"Authorization", "Bearer " ++ token()}],
-    HttpOpts = case filelib:is_file(cert_path()) of
-                   true  -> [{ssl, [{cacertfile, cert_path()}]}];
-                   false -> [{ssl, [{verify, verify_none}]}]
-               end,
-    ekka_httpc:get(Server, service_path(Service, Namespace), [], Headers, HttpOpts).
+  Headers = [{"Authorization", "Bearer " ++ token()}],
+  HttpOpts = case filelib:is_file(cert_path()) of
+               true  -> [{ssl, [{cacertfile, cert_path()}]}];
+               false -> [{ssl, [{verify, verify_none}]}]
+             end,
+  ekka_httpc:get(Server, service_path(Service, Namespace), [], Headers, HttpOpts).
 
 service_path(Service, Namespace) ->
-    lists:concat(["api/v1/namespaces/", Namespace, "/endpoints/", Service]).
+  lists:concat(["api/v1/namespaces/", Namespace, "/endpoints/", Service]).
 
 % namespace() ->
 %     binary_to_list(trim(read_file("namespace", <<"default">>))).
 
 token() ->
-    binary_to_list(trim(read_file("token", <<"">>))).
+  binary_to_list(trim(read_file("token", <<"">>))).
 
 cert_path() -> ?SERVICE_ACCOUNT_PATH ++ "/ca.crt".
 
 read_file(Name, Default) ->
-    case file:read_file(?SERVICE_ACCOUNT_PATH ++ Name) of
-        {ok, Data}     -> Data;
-        {error, Error} -> ?LOG(error, "Cannot read ~s: ~p", [Name, Error]),
-                          Default
-    end.
+  case file:read_file(?SERVICE_ACCOUNT_PATH ++ Name) of
+    {ok, Data}     -> Data;
+    {error, Error} -> ?LOG(error, "Cannot read ~s: ~p", [Name, Error]),
+      Default
+  end.
 
 trim(S) -> binary:replace(S, <<"\n">>, <<>>).
 
 extract_addresses(Type, Response, Namespace) ->
-    lists:flatten(
-      [[ extract_host(Type, Addr, Namespace)
-         || Addr <- maps:get(<<"addresses">>, Subset, [])]
-            || Subset <- maps:get(<<"subsets">>, Response, [])]).
+  lists:flatten(
+    [[ extract_host(Type, Addr, Namespace)
+      || Addr <- maps:get(<<"addresses">>, Subset, [])]
+      || Subset <- maps:get(<<"subsets">>, Response, [])]).
 
 extract_host(ip, Addr, _) ->
-    maps:get(<<"ip">>, Addr);
+  maps:get(<<"ip">>, Addr);
 
 extract_host(hostname, Addr, _) ->
-    maps:get(<<"hostname">>, Addr);
+  maps:get(<<"hostname">>, Addr);
 
 extract_host(dns, Addr, Namespace) ->
-    Ip = binary:replace(maps:get(<<"ip">>, Addr), <<".">>, <<"-">>, [global]),
-    iolist_to_binary([Ip, ".", Namespace, ".pod.cluster.local"]).
+  Ip = binary:replace(maps:get(<<"ip">>, Addr), <<".">>, <<"-">>, [global]),
+  iolist_to_binary([Ip, ".", Namespace, ".pod.cluster.local"]).
 


### PR DESCRIPTION
add new address type "hostname", and optional hostname_suffix configuration item and does the same as rabbitmq in its k8s cluster discovery. 

ekka will use hostname get from apiserver and configured hostname_suffix to build nodename, in this way, every emqx node will have a static node name when deployed using k8s statefulset.  data will survice pod recreate. 
   