### PR TITLE
fix(ekka_guid): support NEW_PID_EXT to generate guid

### DIFF
--- a/src/ekka_guid.erl
+++ b/src/ekka_guid.erl
@@ -37,6 +37,10 @@
         , from_hexstr/1
         ]).
 
+-define(TAG_VERSION, 131).
+-define(PID_EXT, 103).
+-define(NEW_PID_EXT, 88).
+
 -define(MAX_SEQ, 16#FFFF).
 
 -type(guid() :: <<_:128>>).
@@ -84,17 +88,28 @@ npid() ->
       NodeD16, NodeD17, NodeD18, NodeD19, NodeD20>> =
       crypto:hash(sha, erlang:list_to_binary(erlang:atom_to_list(node()))),
 
-    % later, when the pid format changes, handle the different format
-    ExternalTermFormatVersion = 131,
-    PidExtType = 103,
-    <<ExternalTermFormatVersion:8,
-      PidExtType:8,
-      PidBin/binary>> = erlang:term_to_binary(self()),
-    % 72 bits for the Erlang pid
+    PidBin =
+        case erlang:term_to_binary(self()) of
+            <<?TAG_VERSION, ?PID_EXT, B/binary>> ->
+                binary:part(B, erlang:byte_size(B), -9);
+            % format supported in Erlang/OTP 19.0-rc1
+            % required for Erlang/OTP 23.0 (and Erlang/OTP 22.0-rc2)
+            <<?TAG_VERSION, ?NEW_PID_EXT, B/binary>> ->
+                binary:part(B, erlang:byte_size(B), -12)
+        end,
+
+    % 72/86 bits for the Erlang pid
     <<PidID1:8, PidID2:8, PidID3:8, PidID4:8, % ID (Node specific, 15 bits)
       PidSR1:8, PidSR2:8, PidSR3:8, PidSR4:8, % Serial (extra uniqueness)
-      PidCR1:8                       % Node Creation Count
-      >> = binary:part(PidBin, erlang:byte_size(PidBin), -9),
+      PidCreation/binary                      % Node Creation Count
+      >> = PidBin,
+
+    PidCR1 = case PidCreation of
+                 <<D1>> ->
+                     D1;
+                 <<D1, D2, D3, D4>> ->
+                     D1 bxor D2 bxor D3 bxor D4
+             end,
 
     % reduce the 160 bit NodeData checksum to 16 bits
     NodeByte1 = ((((((((NodeD01 bxor NodeD02)

--- a/src/ekka_httpc.erl
+++ b/src/ekka_httpc.erl
@@ -70,6 +70,15 @@ build_url(Addr, Path) ->
 build_url(Addr, Path, Params) ->
     lists:concat([build_url(Addr, Path), "?", build_query(Params)]).
 
+-if(?OTP_RELEASE >= 23).
+build_query(Params) when is_list(Params) ->
+    uri_string:compose_query([{safty(K), safty(V)} || {K, V} <- Params]).
+
+safty(A) when is_atom(A)    -> atom_to_list(A);
+safty(I) when is_integer(I) -> integer_to_list(I);
+safty(T) -> T.
+
+-else.
 build_query(Params) ->
     string:join([urlencode(Param) || Param <- Params], "&").
 
@@ -83,6 +92,7 @@ urlencode(I) when is_integer(I) ->
     urlencode(integer_to_list(I));
 urlencode(B) when is_binary(B) ->
     urlencode(binary_to_list(B)).
+-endif.
 
 parse_response({ok, {{_, Code, _}, _Headers, Body}}) ->
     parse_response({ok, Code, Body});


### PR DESCRIPTION
1. Fix the ekka_guid failures on OTP 23
> In OTP 23 distribution flag DFLAG_BIG_CREATION became mandatory. All pids are now encoded using NEW_PID_EXT, even external pids received as PID_EXT from older nodes.
>
> see: http://erlang.org/doc/apps/erts/erl_ext_dist.html#new_pid_ext

2. Eliminate compiling warnings on OTP 23