### PR TITLE
fix(ekka_mnesia): retry if wait for table timeout

### DIFF
--- a/src/ekka_mnesia.erl
+++ b/src/ekka_mnesia.erl
@@ -306,8 +306,13 @@ wait_for(stop) ->
 
 wait_for(tables) ->
     Tables = mnesia:system_info(local_tables),
-    case mnesia:wait_for_tables(Tables, 150000) of
+    do_wait_for_tables(Tables).
+
+do_wait_for_tables(Tables) ->
+    case mnesia:wait_for_tables(Tables, 30000) of
         ok                   -> ok;
         {error, Reason}      -> {error, Reason};
-        {timeout, BadTables} -> {error, {timeout, BadTables}}
+        {timeout, BadTables} ->
+            logger:warning("~p: still waiting for table(s): ~p", [?MODULE, BadTables]),
+            do_wait_for_tables(BadTables)
     end.


### PR DESCRIPTION
ekka_mnesia should retry if wait for mnesia tables timeout.

This avoids the node runs into inconsistent states as the other nodes
in the cluster in case of node failed to load the tables eventually.

Also, avoid the node boots to later stages before the master node starts
which makes the node not able to self-recover without a manual restart.

fix the emqx issue: https://github.com/emqx/emqx/issues/4535