### PR TITLE
test(rlog): Add a concuerror model of the dirty bootstrap procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ concuerror_test: $(CONCUERROR)
 	$(call concuerror,wait_for_shards_crash_test)
 	$(call concuerror,notify_different_tags_test)
 	$(call concuerror,get_core_node_test)
+	$(call concuerror,dirty_boostrap_test)
 
 $(CONCUERROR):
 	mkdir -p _build/

--- a/src/ekka_rlog_agent.erl
+++ b/src/ekka_rlog_agent.erl
@@ -17,10 +17,6 @@
 %% @doc This module implements a gen_statem which pushes rlogs to
 %% a remote node.
 %%
-%% The state machine consists of 3 states:
-%% `catchup', `switchover', `normal', which are explained in detail below:
-%%
-%%
 %% All sends are done as `gen_rpc' calls to the replicant node.
 
 -module(ekka_rlog_agent).


### PR DESCRIPTION
No functional change, just adding a new Concuerror model