### PR TITLE
fix ekka_mnesia:running_nodes

### DIFF
--- a/src/ekka_mnesia.erl
+++ b/src/ekka_mnesia.erl
@@ -319,7 +319,7 @@ running_nodes() ->
     case ekka_rlog:role() of
         core ->
             CoreNodes = mnesia:system_info(running_db_nodes),
-            {Replicants0, _} = rpc:multicall(CoreNodes, ekka_rlog_status, replicants, [], 1000),
+            {Replicants0, _} = rpc:multicall(CoreNodes, ekka_rlog_status, replicants, []),
             Replicants = [Node || Nodes <- Replicants0, is_list(Nodes), Node <- Nodes],
             lists:usort(CoreNodes ++ Replicants);
         replicant ->

--- a/src/ekka_rlog_agent.erl
+++ b/src/ekka_rlog_agent.erl
@@ -102,9 +102,6 @@ handle_event(EventType, Event, State, D) ->
 code_change(_OldVsn, State, Data, _Extra) ->
     {ok, State, Data}.
 
-%% terminate(_Reason, _State, #d{subscriber = Sub, shard = Shard}) ->
-%%     ekka_rlog_status:notify_agent_disconnect(Shard, ekka_rlog_lib:subscriber_node(Sub)),
-%%     ok;
 terminate(_Reason, _State, _Data) ->
     ok.
 

--- a/src/ekka_rlog_agent.erl
+++ b/src/ekka_rlog_agent.erl
@@ -102,6 +102,9 @@ handle_event(EventType, Event, State, D) ->
 code_change(_OldVsn, State, Data, _Extra) ->
     {ok, State, Data}.
 
+%% terminate(_Reason, _State, #d{subscriber = Sub, shard = Shard}) ->
+%%     ekka_rlog_status:notify_agent_disconnect(Shard, ekka_rlog_lib:subscriber_node(Sub)),
+%%     ok;
 terminate(_Reason, _State, _Data) ->
     ok.
 

--- a/src/ekka_rlog_lb.erl
+++ b/src/ekka_rlog_lb.erl
@@ -114,6 +114,6 @@ core_node_weight(Shard) ->
             Load = 0,
             %% The return values will be lexicographically sorted. Load will
             %% be distributed evenly between the nodes with the same weight
-            %% due to random term:
+            %% due to the random term:
             {ok, {Load, rand:uniform(), node()}}
     end.

--- a/src/ekka_rlog_lb.erl
+++ b/src/ekka_rlog_lb.erl
@@ -111,7 +111,9 @@ core_node_weight(Shard) ->
         undefined ->
             undefined;
         _Pid ->
-            Load = 0,
+            NAgents = length(ekka_rlog_status:agents()),
+            %% TODO: Add OLP check
+            Load = 1.0 * NAgents,
             %% The return values will be lexicographically sorted. Load will
             %% be distributed evenly between the nodes with the same weight
             %% due to the random term:

--- a/src/ekka_rlog_lib.erl
+++ b/src/ekka_rlog_lib.erl
@@ -26,6 +26,7 @@
         , shuffle/1
         , send_after/3
         , cancel_timer/1
+        , subscriber_node/1
         ]).
 
 -export_type([ tlog_entry/0
@@ -192,6 +193,10 @@ cancel_timer(undefined) ->
     ok;
 cancel_timer(TRef) ->
     erlang:cancel_timer(TRef).
+
+-spec subscriber_node(subscriber()) -> node().
+subscriber_node({Node, _Pid}) ->
+    Node.
 
 %%================================================================================
 %% Internal

--- a/test/ekka_ct.erl
+++ b/test/ekka_ct.erl
@@ -170,7 +170,12 @@ node_id(Name) ->
 run_on(Node, Fun) ->
     %% Sending closures over erlang distribution is wrong, but for
     %% test purposes it should be ok.
-    rpc:call(Node, erlang, apply, [Fun, []]).
+    case rpc:call(Node, erlang, apply, [Fun, []]) of
+        {badrpc, Err} ->
+            error(Err);
+        Result ->
+            Result
+    end.
 
 set_network_delay(N) ->
     ok = file:write_file("/tmp/nemesis", integer_to_list(N) ++ "us\n").

--- a/test/ekka_mnesia_SUITE.erl
+++ b/test/ekka_mnesia_SUITE.erl
@@ -93,22 +93,22 @@ t_cluster_status(_) ->
 
 %% -spec(remove_from_cluster(node()) -> ok | {error, any()}).
 t_remove_from_cluster(_) ->
-    Cluster = ekka_ct:cluster([core, core], []),
+    Cluster = ekka_ct:cluster([core, core, replicant, replicant], []),
     try
-        [N0, N1] = ekka_ct:start_cluster(ekka, Cluster),
+        [N0, N1, N2, N3] = ekka_ct:start_cluster(ekka, Cluster),
         ekka_ct:run_on(N0, fun() ->
-            #{running_nodes := [N0, N1]} = ekka_mnesia:cluster_info(),
-            [N0, N1] = lists:sort(ekka_mnesia:running_nodes()),
-            [N0, N1] = lists:sort(ekka_mnesia:cluster_nodes(all)),
-            [N0, N1] = lists:sort(ekka_mnesia:cluster_nodes(running)),
+            #{running_nodes := [N0, N1, N2, N3]} = ekka_mnesia:cluster_info(),
+            [N0, N1, N2, N3] = lists:sort(ekka_mnesia:running_nodes()),
+            [N0, N1, N2, N3] = lists:sort(ekka_mnesia:cluster_nodes(all)),
+            [N0, N1, N2, N3] = lists:sort(ekka_mnesia:cluster_nodes(running)),
             [] = ekka_mnesia:cluster_nodes(stopped),
             ok
           end),
-        ekka_ct:run_on(N1, fun() ->
-            #{running_nodes := [N0, N1]} = ekka_mnesia:cluster_info(),
-            [N0, N1] = lists:sort(ekka_mnesia:running_nodes()),
-            [N0, N1] = lists:sort(ekka_mnesia:cluster_nodes(all)),
-            [N0, N1] = lists:sort(ekka_mnesia:cluster_nodes(running)),
+        ekka_ct:run_on(N2, fun() ->
+            #{running_nodes := [N0, N1, N2, N3]} = ekka_mnesia:cluster_info(),
+            [N0, N1, N2, N3] = lists:sort(ekka_mnesia:running_nodes()),
+            [N0, N1, N2, N3] = lists:sort(ekka_mnesia:cluster_nodes(all)),
+            [N0, N1, N2, N3] = lists:sort(ekka_mnesia:cluster_nodes(running)),
             [] = ekka_mnesia:cluster_nodes(stopped),
             ok
           end),
@@ -332,8 +332,11 @@ t_sum_verify(_) ->
                            )
        end).
 
-t_load_balancing(_) ->
-    Cluster = ekka_ct:cluster([core, core, replicant], ekka_mnesia_test_util:common_env()),
+%% Test behavior of the replicant waiting for the core node
+t_core_node_down(_) ->
+    Cluster = ekka_ct:cluster( [core, core, replicant]
+                             , ekka_mnesia_test_util:common_env()
+                             ),
     NTrans = 100,
     ?check_trace(
        try


### PR DESCRIPTION
`ekka_mnesia:running_nodes()` now includes replicant nodes. Also this PR fixes some unstable testcases