### PR TITLE
fix: dup calls to force mnesia schema merge from remote node

### DIFF
--- a/src/ekka_mnesia.erl
+++ b/src/ekka_mnesia.erl
@@ -406,6 +406,9 @@ do_wait_for_tables(Tables) ->
         {error, Reason}      -> {error, Reason};
         {timeout, BadTables} ->
             logger:warning("~p: still waiting for table(s): ~p", [?MODULE, BadTables]),
+            %% lets try to force reconnect all the db_nodes to get schema merged,
+            %% mnesia_controller is smart enough to not force reconnect the node that is already connected.
+            mnesia_controller:connect_nodes(mnesia:system_info(db_nodes)),
             do_wait_for_tables(BadTables)
     end.
 


### PR DESCRIPTION
fix https://github.com/emqx/emqx/issues/5254

I have manually tested in a minikube env.