### PR TITLE
fix: dup calls to force mnesia schema merge from remote node

### DIFF
--- a/src/ekka.appup.src
+++ b/src/ekka.appup.src
@@ -1,14 +1,14 @@
 %% -*-: erlang -*-
 
-{"0.7.5",
+{"0.8.1.1",
   [
-    {"0.7.4", [
-      {load_module, ekka_locker, brutal_purge, soft_purge, []}
+    {"0.8.1", [
+      {load_module, ekka_mnesia, brutal_purge, soft_purge, []}
     ]}
   ],
   [
-    {"0.7.4", [
-      {load_module, ekka_locker, brutal_purge, soft_purge, []}
+    {"0.8.1", [
+      {load_module, ekka_mnesia, brutal_purge, soft_purge, []}
     ]}
   ]
 }.

--- a/src/ekka_mnesia.erl
+++ b/src/ekka_mnesia.erl
@@ -314,5 +314,8 @@ do_wait_for_tables(Tables) ->
         {error, Reason}      -> {error, Reason};
         {timeout, BadTables} ->
             logger:warning("~p: still waiting for table(s): ~p", [?MODULE, BadTables]),
+            %% lets try to force reconnect all the db_nodes to get schema merged,
+            %% mnesia_controller is smart enough to not force reconnect the node that is already connected.
+            mnesia_controller:connect_nodes(mnesia:system_info(db_nodes)),
             do_wait_for_tables(BadTables)
     end.


### PR DESCRIPTION
fix https://github.com/emqx/emqx/issues/5254
backport to 4.3