### PR TITLE
feat(rlog): Implement support for local_content tables

### DIFF
--- a/doc/rlog.md
+++ b/doc/rlog.md
@@ -53,13 +53,7 @@ Thankfully, migration from plain mnesia to RLOG is rather simple.
 ### Assigning tables to the shards
 
 First, each mnesia table should be assigned to an RLOG shard.
-It is done either by adding a special annotation:
-
-```erlang
--rlog_shard({shard_name, table_name}).
-```
-
-or by adding `{rlog_shard, shard_name}` tuple to the option list of `ekka_mnesia:create_table` function.
+It is done by adding `{rlog_shard, shard_name}` tuple to the option list of `ekka_mnesia:create_table` function.
 
 For example:
 
@@ -69,10 +63,9 @@ For example:
 -boot_mnesia({mnesia, [boot]}).
 -copy_mnesia({mnesia, [copy]}).
 
--rlog_shard({route_shard, emqx_route}).
-
 mnesia(boot) ->
     ok = ekka_mnesia:create_table(emqx_route, [{type, bag},
+                                               {rlog_shard, emqx_route},
                                                {ram_copies, [node()]},
                                               ]),
     ok = ekka_mnesia:create_table(emqx_trie, [{type, bag},

--- a/src/ekka_mnesia.erl
+++ b/src/ekka_mnesia.erl
@@ -76,6 +76,7 @@
 -export_type([ t_result/1
              , backend/0
              , table/0
+             , table_config/0
              ]).
 
 -deprecated({copy_table, 1, next_major_release}).
@@ -185,7 +186,7 @@ create_table(Name, TabDef) ->
                 ok ->
                     %% It's important to add the table to the shard
                     %% _after_ we actually create it:
-                    ekka_rlog_schema:add_table(Shard, Name, TabDef);
+                    ekka_rlog_schema:add_table(Shard, Name, MnesiaTabDef);
                 Err ->
                     Err
             end;

--- a/src/ekka_mnesia.erl
+++ b/src/ekka_mnesia.erl
@@ -84,7 +84,9 @@
 
 -type backend() :: rlog | mnesia.
 
--type table():: atom().
+-type table() :: atom().
+
+-type table_config() :: list().
 
 %%--------------------------------------------------------------------
 %% Start and init mnesia

--- a/src/ekka_rlog.erl
+++ b/src/ekka_rlog.erl
@@ -87,7 +87,8 @@ core_nodes() ->
     application:get_env(ekka, core_nodes, []).
 
 -spec wait_for_shards([shard()], timeout()) -> ok | {timeout, [shard()]}.
-wait_for_shards(Shards, Timeout) ->
+wait_for_shards(Shards0, Timeout) ->
+    Shards = [I || I <- Shards0, I =/= ?LOCAL_CONTENT_SHARD],
     case ekka_rlog_config:backend() of
         rlog ->
             lists:foreach(fun ensure_shard/1, Shards),

--- a/src/ekka_rlog.erl
+++ b/src/ekka_rlog.erl
@@ -107,7 +107,11 @@ ensure_shard(Shard) ->
     end.
 
 -spec subscribe(ekka_rlog:shard(), node(), pid(), ekka_rlog_server:checkpoint()) ->
-          {ok, _NeedBootstrap :: boolean(), _Agent :: pid(), [ekka_mnesia:table()]}
+          { ok
+          , _NeedBootstrap :: boolean()
+          , _Agent :: pid()
+          , [{ekka_mnesia:table(), ekka_mnesia:table_config()}]
+          }
         | {badrpc | badtcp, term()}.
 subscribe(Shard, RemoteNode, Subscriber, Checkpoint) ->
     case ekka_rlog_server:probe(RemoteNode, Shard) of

--- a/src/ekka_rlog.hrl
+++ b/src/ekka_rlog.hrl
@@ -11,7 +11,7 @@
 -record(?schema,
         { mnesia_table :: ekka_mnesia:table()
         , shard        :: ekka_rlog:shard()
-        , config       :: list() | '_'
+        , config       :: ekka_mnesia:table_config() | '_'
         }).
 
 -define(LOCAL_CONTENT_SHARD, undefined).

--- a/src/ekka_rlog.hrl
+++ b/src/ekka_rlog.hrl
@@ -11,7 +11,7 @@
 -record(?schema,
         { mnesia_table :: ekka_mnesia:table()
         , shard        :: ekka_rlog:shard()
-        , config       :: ekka_mnesia:table_config() | '_'
+        , config       :: ekka_mnesia:table_config() | '$2' | '_' %% TODO: fix type
         }).
 
 -define(LOCAL_CONTENT_SHARD, undefined).

--- a/src/ekka_rlog.hrl
+++ b/src/ekka_rlog.hrl
@@ -13,4 +13,6 @@
         , shard        :: ekka_rlog:shard()
         }).
 
+-define(LOCAL_CONTENT_SHARD, undefined).
+
 -endif.

--- a/src/ekka_rlog.hrl
+++ b/src/ekka_rlog.hrl
@@ -11,6 +11,7 @@
 -record(?schema,
         { mnesia_table :: ekka_mnesia:table()
         , shard        :: ekka_rlog:shard()
+        , config       :: list() | '_'
         }).
 
 -define(LOCAL_CONTENT_SHARD, undefined).

--- a/src/ekka_rlog_replica.erl
+++ b/src/ekka_rlog_replica.erl
@@ -298,9 +298,9 @@ handle_reconnect(#d{shard = Shard, checkpoint = Checkpoint}) ->
                   , agent            = ConnPid
                   , remote_core_node = Node
                   },
-            ok = ekka_rlog_schema:converge(Shard, TableSpecs),
             {Tables, _} = lists:unzip(TableSpecs),
             ekka_rlog_config:load_shard_config(Shard, Tables),
+            ok = ekka_rlog_schema:converge(Shard, TableSpecs),
             {next_state, ?bootstrap, D};
         {ok, _BootstrapNeeded = false, Node, ConnPid, TableSpecs} ->
             D = #d{ shard            = Shard
@@ -308,9 +308,9 @@ handle_reconnect(#d{shard = Shard, checkpoint = Checkpoint}) ->
                   , remote_core_node = Node
                   , checkpoint       = Checkpoint
                   },
-            ok = ekka_rlog_schema:converge(Shard, TableSpecs),
             {Tables, _} = lists:unzip(TableSpecs),
             ekka_rlog_config:load_shard_config(Shard, Tables),
+            ok = ekka_rlog_schema:converge(Shard, TableSpecs),
             {next_state, ?normal, D};
         {error, Err} ->
             ?tp(debug, "Replicant couldn't connect to the upstream node",

--- a/src/ekka_rlog_replica.erl
+++ b/src/ekka_rlog_replica.erl
@@ -298,6 +298,7 @@ handle_reconnect(#d{shard = Shard, checkpoint = Checkpoint}) ->
                   , agent            = ConnPid
                   , remote_core_node = Node
                   },
+            {Tables, Tables} = {Tables, ekka_rlog_schema:tables_of_shard(Shard)}, %% Assert
             ekka_rlog_config:load_shard_config(Shard, Tables),
             {next_state, ?bootstrap, D};
         {ok, _BootstrapNeeded = false, Node, ConnPid, Tables} ->
@@ -306,6 +307,7 @@ handle_reconnect(#d{shard = Shard, checkpoint = Checkpoint}) ->
                   , remote_core_node = Node
                   , checkpoint       = Checkpoint
                   },
+            {Tables, Tables} = {Tables, ekka_rlog_schema:tables_of_shard(Shard)}, %% Assert
             ekka_rlog_config:load_shard_config(Shard, Tables),
             {next_state, ?normal, D};
         {error, Err} ->

--- a/src/ekka_rlog_schema.erl
+++ b/src/ekka_rlog_schema.erl
@@ -88,7 +88,7 @@ init(boot) ->
                                                      {attributes, record_info(fields, ?schema)}
                                                     ]),
     ekka_mnesia:wait_for_tables([?schema]),
-    load_static_config();
+    ok;
 init(copy) ->
     ?tp(debug, rlog_schema_init,
         #{ type => copy
@@ -126,14 +126,6 @@ shards() ->
 %%================================================================================
 %% Internal functions
 %%================================================================================
-
--spec load_static_config() -> ok.
-load_static_config() ->
-    lists:foreach( fun({_App, _Module, Attrs}) ->
-                           [add_table(Shard, Table) || {Shard, Table} <- Attrs]
-                   end
-                 , ekka_boot:all_module_attributes(rlog_shard)
-                 ).
 
 -spec do_add_table(ekka_rlog:shard(), ekka_mnesia:table()) -> ok.
 do_add_table(Shard, Table) ->

--- a/test/ekka_mnesia_SUITE.erl
+++ b/test/ekka_mnesia_SUITE.erl
@@ -29,6 +29,7 @@
 all() -> ekka_ct:all(?MODULE).
 
 init_per_suite(Config) ->
+    snabbkaffe:fix_ct_logging(),
     Config.
 
 end_per_suite(_Config) ->
@@ -130,7 +131,6 @@ t_remove_from_cluster(_) ->
 %% the stages of startup and online transaction replication, so it can
 %% be used to check if anything is _obviously_ broken.
 t_rlog_smoke_test(_) ->
-    snabbkaffe:fix_ct_logging(),
     Env = [ {ekka, bootstrapper_chunk_config, #{count_limit => 3}}
           | ekka_mnesia_test_util:common_env()
           ],
@@ -256,7 +256,6 @@ t_core_node_competing_writes(_) ->
        end).
 
 t_rlog_clear_table(_) ->
-    snabbkaffe:fix_ct_logging(),
     Cluster = ekka_ct:cluster([core, replicant], ekka_mnesia_test_util:common_env()),
     ?check_trace(
        try
@@ -276,7 +275,6 @@ t_rlog_clear_table(_) ->
        end).
 
 t_rlog_dirty_operations(_) ->
-    snabbkaffe:fix_ct_logging(),
     Cluster = ekka_ct:cluster([core, core, replicant], ekka_mnesia_test_util:common_env()),
     ?check_trace(
        try
@@ -492,7 +490,6 @@ t_dirty_reads(_) ->
 
 %% Test adding tables to the schema:
 t_rlog_schema(_) ->
-    snabbkaffe:fix_ct_logging(),
     Cluster = ekka_ct:cluster([core, replicant], ekka_mnesia_test_util:common_env()),
     ?check_trace(
        try
@@ -552,7 +549,6 @@ t_rlog_schema(_) ->
        end).
 
 cluster_benchmark(_) ->
-    snabbkaffe:fix_ct_logging(),
     NReplicas = 6,
     Config = #{ trans_size => 10
               , max_time   => 15000

--- a/test/ekka_mnesia_SUITE.erl
+++ b/test/ekka_mnesia_SUITE.erl
@@ -311,6 +311,85 @@ t_rlog_dirty_operations(_) ->
                ?assert(ekka_rlog_props:replicant_no_restarts(Trace))
        end).
 
+t_local_content(_) ->
+    Cluster = ekka_ct:cluster([core, replicant], ekka_mnesia_test_util:common_env()),
+    ?check_trace(
+      try
+          Nodes = [N1, N2] = ekka_ct:start_cluster(ekka, Cluster),
+          %% Create the table on all nodes:
+          {[ok, ok], []} = rpc:multicall(Nodes, ekka_mnesia, create_table,
+                                         [local_tab,
+                                          [{local_content, true}]
+                                         ]),
+          %% Perform an invalid r/w transactions on both nodes:
+          [?assertMatch( {aborted, {invalid_transaction, _, _}}
+                       , rpc:call(N, ekka_mnesia, transaction,
+                                  [ekka_mnesia:local_content_shard(),
+                                   fun() ->
+                                           ok = mnesia:write({test_tab, key, val})
+                                   end
+                                  ])
+                       )
+           || N <- Nodes],
+          [?assertMatch( {aborted, {invalid_transaction, _, _}}
+                       , rpc:call(N, ekka_mnesia, transaction,
+                                  [test_shard,
+                                   fun() ->
+                                           ok = mnesia:write({local_tab, key, val})
+                                   end
+                                  ])
+                       )
+           || N <- Nodes],
+          %% Perform r/w transactions on both nodes with different content:
+          ?assertMatch( {atomic, N1}
+                      , rpc:call(N1, ekka_mnesia, transaction,
+                                  [ekka_mnesia:local_content_shard(),
+                                   fun() ->
+                                           mnesia:write({local_tab, key, node()}),
+                                           node()
+                                   end
+                                  ])
+                       ),
+          ?assertMatch( {atomic, N2}
+                      , rpc:call(N2, ekka_mnesia, transaction,
+                                  [ekka_mnesia:local_content_shard(),
+                                   fun() ->
+                                           mnesia:write({local_tab, key, node()}),
+                                           node()
+                                   end
+                                  ])
+                       ),
+          %% Perform a successful r/o transaction:
+          [?assertMatch( {atomic, N}
+                       , rpc:call(N, ekka_mnesia, ro_transaction,
+                                  [ekka_mnesia:local_content_shard(),
+                                   fun() ->
+                                           [key] = mnesia:all_keys(local_tab),
+                                           Node = node(),
+                                           [{local_tab, key, Node}] = mnesia:read(local_tab, key),
+                                           Node
+                                   end
+                                  ])
+                       )
+           || N <- Nodes],
+          %% Perform an invalid r/o transaction, it should abort:
+          [?assertMatch( {aborted, _}
+                       , rpc:call(N, ekka_mnesia, ro_transaction,
+                                  [ekka_mnesia:local_content_shard(),
+                                   fun() ->
+                                           mnesia:write({local_tab, 1, 1})
+                                   end
+                                  ])
+                       )
+           || N <- Nodes],
+          ok
+      after
+          ekka_ct:teardown_cluster(Cluster)
+      end,
+      fun(_, _) ->
+              true
+      end).
+
 %% This testcase verifies verifies various modes of ekka_mnesia:ro_transaction
 t_sum_verify(_) ->
     Cluster = ekka_ct:cluster([core, replicant], ekka_mnesia_test_util:common_env()),

--- a/test/ekka_mnesia_SUITE.erl
+++ b/test/ekka_mnesia_SUITE.erl
@@ -50,6 +50,7 @@ t_create_del_table(_) ->
         ekka:start(),
         ok = ekka_mnesia:create_table(kv_tab, [
                     {ram_copies, [node()]},
+                    {rlog_shard, test_shard},
                     {record_name, kv_tab},
                     {attributes, record_info(fields, kv_tab)},
                     {storage_properties, []}]),

--- a/test/ekka_mnesia_test_util.erl
+++ b/test/ekka_mnesia_test_util.erl
@@ -66,4 +66,5 @@ compare_table_contents(Table, Nodes) ->
 common_env() ->
     [ {ekka, db_backend, rlog}
     , {ekka, rlog_startup_shards, [test_shard]}
+    , {ekka, strict_mode, true}
     ].

--- a/test/test_src/ekka_helper_tab.erl
+++ b/test/test_src/ekka_helper_tab.erl
@@ -27,7 +27,6 @@
 
 -boot_mnesia({mnesia, [boot]}).
 -copy_mnesia({mnesia, [copy]}).
--rlog_shard({test_shard, ?TABLE}).
 
 -record(?TABLE, {key, val}).
 
@@ -35,6 +34,7 @@
 
 mnesia(boot) ->
     ok = ekka_mnesia:create_table(?TABLE, [{type, ordered_set},
+                                           {rlog_shard, test_shard},
                                            {ram_copies, [node()]},
                                            {record_name, ?TABLE},
                                            {attributes, record_info(fields, ?TABLE)}

--- a/test/test_src/ekka_transaction_gen.erl
+++ b/test/test_src/ekka_transaction_gen.erl
@@ -19,8 +19,6 @@
 
 -boot_mnesia({mnesia, [boot]}).
 -copy_mnesia({mnesia, [copy]}).
--rlog_shard({test_shard, test_tab}).
--rlog_shard({test_shard, test_bag}).
 
 -export([ init/0
         , delete/1
@@ -40,11 +38,13 @@
 
 mnesia(boot) ->
     ok = ekka_mnesia:create_table(test_tab, [{type, ordered_set},
+                                             {rlog_shard, test_shard},
                                              {ram_copies, [node()]},
                                              {record_name, test_tab},
                                              {attributes, record_info(fields, test_tab)}
                                             ]),
     ok = ekka_mnesia:create_table(test_bag, [{type, bag},
+                                             {rlog_shard, test_shard},
                                              {ram_copies, [node()]},
                                              {record_name, test_bag},
                                              {attributes, record_info(fields, test_bag)}


### PR DESCRIPTION
A few changes that finally made it work with the current version of EMQ X:
1) Implement handling of local_content tables
2) Drop support for `-rlog_shard` annotation, and keep only one way of defining tables
3) Replicants' schema is forcibly converged to the core nodes' view 