### PR TITLE
fix(etcd): check ssl enable

### DIFF
--- a/src/ekka_cluster_etcd.erl
+++ b/src/ekka_cluster_etcd.erl
@@ -194,7 +194,11 @@ server(Options) ->
 ssl_options(Options) ->
     case proplists:get_value(ssl_options, Options, []) of
         [] -> [];
-        SSLOptions -> [{ssl, SSLOptions}]
+        SSLOptions ->
+            case proplists:get_value(enable, SSLOptions, true) of
+                true -> [{ssl, proplists:delete(enable, SSLOptions)}];
+                false -> []
+            end
     end.
 
 config(Key, Options) ->


### PR DESCRIPTION
fix regression,

check if SSL is disabled or not and also prevent the enable parm leak to SSL options.

Without this check, there seems no way to disable the SSL.