### PR TITLE
fix(locker): the locker crashed when trying to release locks

### DIFF
--- a/src/ekka.appup.src
+++ b/src/ekka.appup.src
@@ -1,7 +1,10 @@
 %% -*-: erlang -*-
-{"0.7.9",
+{"0.7.10",
  [
- {"0.7.8", [
+  {"0.7.9", [
+    {load_module, ekka_locker, brutal_purge, soft_purge, []}
+  ]},
+  {"0.7.8", [
     {load_module, ekka_mnesia, brutal_purge, soft_purge, []},
     {load_module, ekka_locker, brutal_purge, soft_purge, []}
   ]},
@@ -16,7 +19,10 @@
   ]}
  ],
  [
- {"0.7.8", [
+  {"0.7.9", [
+    {load_module, ekka_locker, brutal_purge, soft_purge, []}
+  ]},
+  {"0.7.8", [
     {load_module, ekka_mnesia, brutal_purge, soft_purge, []},
     {load_module, ekka_locker, brutal_purge, soft_purge, []}
   ]},

--- a/src/ekka_locker.erl
+++ b/src/ekka_locker.erl
@@ -268,7 +268,8 @@ handle_info(check_lease, State = #state{locks = Tab, lease = Lease, monitors = M
                                     true ->
                                         %% force kill it as it might have hung
                                         logger:error("kill ~p as it has held the lock for too long, resource: ~p", [Owner, Resource]),
-                                        exit(Owner, kill);
+                                        exit(Owner, kill),
+                                        MonAcc;
                                     false ->
                                         maps:put(Owner, set_put(Resource, ResourceSet), MonAcc)
                                 end;


### PR DESCRIPTION
```
2021-11-09 08:18:09.568 [error] ** Generic server emqx_cm_locker terminating 
** Last message in was {'DOWN',#Ref<0.1914890529.1843920897.137756>,process,
                               <59068.27251.351>,killed}
** When Server state == {state,emqx_cm_locker,
                         {lease,15000,
                          {ok,
                           {interval,#Ref<0.1914890528.4267704322.100681>}}},
                         true}
** Reason for termination ==
** {{badmap,true},
    [{maps,find,[<59068.27251.351>,true],[]},
     {ekka_locker,handle_info,2,
                  [{file,"/Users/liuxy/code/emqx-enterprise-rel/_build/emqx/lib/ekka/src/ekka_locker.erl"},
                   {line,283}]},
     {gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,637}]},
     {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,711}]},
     {proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,259}]}]}
```