### PR TITLE
chore(appup): bump appup and version to 0.8.1.6

### DIFF
--- a/src/ekka.appup.src
+++ b/src/ekka.appup.src
@@ -1,7 +1,11 @@
 %% -*- mode: erlang -*-
-{"0.8.1.5",
-  [{"0.8.1.4",
-    [{load_module,ekka_node_monitor,brutal_purge,soft_purge,[]}
+{"0.8.1.6",
+  [{"0.8.1.5",
+    [{load_module,ekka_node_monitor,brutal_purge,soft_purge,[]},
+     {load_module,ekka_cluster_dns,brutal_purge,soft_purge,[]}]},
+   {"0.8.1.4",
+    [{load_module,ekka_cluster_dns,brutal_purge,soft_purge,[]},
+     {load_module,ekka_node_monitor,brutal_purge,soft_purge,[]}
     ]},
    {"0.8.1.3",
     [{load_module,ekka_node_monitor,brutal_purge,soft_purge,[]},
@@ -35,8 +39,12 @@
      {load_module,ekka_locker,brutal_purge,soft_purge,[]},
      {load_module,ekka_httpc,brutal_purge,soft_purge,[]},
      {load_module,ekka_mnesia,brutal_purge,soft_purge,[]}]}],
-  [{"0.8.1.4",
-    [{load_module,ekka_node_monitor,brutal_purge,soft_purge,[]}
+  [{"0.8.1.5",
+    [{load_module,ekka_node_monitor,brutal_purge,soft_purge,[]},
+     {load_module,ekka_cluster_dns,brutal_purge,soft_purge,[]}]},
+   {"0.8.1.4",
+    [{load_module,ekka_cluster_dns,brutal_purge,soft_purge,[]},
+     {load_module,ekka_node_monitor,brutal_purge,soft_purge,[]}
     ]},
    {"0.8.1.3",
     [{load_module,ekka_node_monitor,brutal_purge,soft_purge,[]},


### PR DESCRIPTION
We're doing this to remove some missing change warnings when updating
emqx v4.3.10.