### PR TITLE
feat(core_node_discovery): add mria core node discovery callback

### DIFF
--- a/src/ekka_autocluster.erl
+++ b/src/ekka_autocluster.erl
@@ -172,30 +172,12 @@ core_node_discovery_callback() ->
       fun(Mod, Opts) ->
               case Mod:discover(Opts) of
                   {ok, Nodes} ->
-                      filter_core_nodes(Nodes);
+                      Nodes;
                   {error, Reason} ->
                       ?LOG(error, "Core node discovery error: ~p", [Reason]),
                       []
               end
       end).
-
-filter_core_nodes(Nodes) ->
-    Responses0 = erpc:multicall(Nodes, mria_config, role, [], 5000),
-    Responses1 = lists:zip(Nodes, Responses0),
-    {Successes, Errors} =
-        lists:partition(
-          fun({_Node, {ok, _}}) ->
-                  true;
-             ({_Node, _Error}) ->
-                  false
-          end,
-          Responses1),
-    lists:foreach(
-      fun({Node, Error}) ->
-              ?LOG(error, "Core node discovery error on node ~p: ~p", [Node, Error])
-      end,
-      Errors),
-    [Node || {Node, {ok, core}} <- Successes].
 
 log_error(Format, {error, Reason}) ->
     ?LOG(error, Format ++ " error: ~p", [Reason]);

--- a/src/ekka_boot.erl
+++ b/src/ekka_boot.erl
@@ -30,7 +30,9 @@ create_tables() ->
 %% @dec Register actions that will be performed during Mria heal
 register_mria_callbacks() ->
     mria_config:register_callback(start, fun ekka:start/0),
-    mria_config:register_callback(stop, fun ekka:stop/0).
+    mria_config:register_callback(stop, fun ekka:stop/0),
+    mria_config:register_callback(core_node_discovery,
+                                  fun ekka_autocluster:core_node_discovery_callback/0).
 
 %% only {F, Args}...
 apply_module_attributes(Name) ->

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -178,9 +178,9 @@ t_core_node_discovery_callback(_Config) ->
         _ = rpc:call(N1, ekka, autocluster, []),
         _ = rpc:call(N2, ekka, autocluster, []),
         ok = wait_for_node(N1),
-        %% n2 is not returned as it is a replicant
+        %% filtering the core nodes is done by mria
         ?assertEqual(
-           ['ct@127.0.0.1', 'n1@127.0.0.1'],
+           ['ct@127.0.0.1', 'n1@127.0.0.1', 'n2@127.0.0.1'],
            erpc:call(N2, ekka_autocluster, core_node_discovery_callback, [], 5000)
           ),
         ok = ekka:force_leave(N1)

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -53,6 +53,7 @@ all() -> ekka_ct:all(?MODULE).
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
+    application:set_env(gen_rpc, port_discovery, stateless),
     Config.
 
 end_per_suite(_Config) ->
@@ -154,6 +155,41 @@ reboot_ekka_with_mcast_env() ->
     ok = ekka:stop(),
     ok = set_app_env(node(), {mcast, ?MCAST_OPTIONS}),
     ok = ekka:start().
+
+%%--------------------------------------------------------------------
+%% Core node discovery callback
+
+t_core_node_discovery_callback(_Config) ->
+    {ok, _} = start_etcd_server(2379),
+    application:set_env(ekka, test_etcd_nodes, [ "ct@127.0.0.1"
+                                               , "n1@127.0.0.1"
+                                               , "n2@127.0.0.1"
+                                               ]),
+    N1 = ekka_ct:start_slave(ekka, n1, [ {mria, db_backend, rlog}
+                                       ]),
+    N2 = ekka_ct:start_slave(ekka, n2, [ {mria, db_backend, rlog}
+                                       , {mria, node_role, replicant}
+                                       ]),
+    try
+        ok = ekka_ct:wait_running(N1),
+        ok = ekka_ct:wait_running(N2),
+        ok = set_app_env(N1, {etcd, ?ETCD_OPTIONS}),
+        ok = set_app_env(N2, {etcd, ?ETCD_OPTIONS}),
+        _ = rpc:call(N1, ekka, autocluster, []),
+        _ = rpc:call(N2, ekka, autocluster, []),
+        ok = wait_for_node(N1),
+        %% n2 is not returned as it is a replicant
+        ?assertEqual(
+           ['ct@127.0.0.1', 'n1@127.0.0.1'],
+           erpc:call(N2, ekka_autocluster, core_node_discovery_callback, [], 5000)
+          ),
+        ok = ekka:force_leave(N1)
+    after
+        ok = stop_etcd_server(2379),
+        application:unset_env(ekka, test_etcd_nodes),
+        ok = ekka_ct:stop_slave(N1),
+        ok = ekka_ct:stop_slave(N2)
+    end.
 
 %%--------------------------------------------------------------------
 %% Helper functions

--- a/test/ekka_boot_SUITE.erl
+++ b/test/ekka_boot_SUITE.erl
@@ -32,3 +32,23 @@ t_apply_module_attributes(_) ->
 t_all_module_attributes(_) ->
     [] = ekka_boot:all_module_attributes(xattr).
 
+t_register_mria_callbacks(_) ->
+    try
+        ok = ekka_boot:register_mria_callbacks(),
+        ?assertEqual(
+           {ok, fun ekka:start/0},
+           mria_config:callback(start)),
+        ?assertEqual(
+           {ok, fun ekka:stop/0},
+           mria_config:callback(stop)),
+        ?assertEqual(
+           {ok, fun ekka_autocluster:core_node_discovery_callback/0},
+           mria_config:callback(core_node_discovery))
+    after
+        lists:foreach(
+          fun mria_config:unregister_callback/1,
+          [ start
+          , stop
+          , core_node_discovery
+          ])
+    end.


### PR DESCRIPTION
This adds support for core node discovery for mria, as it will help
operators configure their nodes when using RLOG as the DB Backend in
mria.

Related to emqx/mria#38 .