### PR TITLE
fix(etcd): link `ekka_cluster_etcd` to eetcd client

### DIFF
--- a/src/ekka_cluster_etcd.erl
+++ b/src/ekka_cluster_etcd.erl
@@ -334,7 +334,8 @@ init(Options) ->
         [] -> {tcp, []};
         [SSL] -> SSL
     end,
-    {ok, _Pid} = eetcd:open(?MODULE, Hosts, Transport, TransportOpts),
+    {ok, Pid} = eetcd:open(?MODULE, Hosts, Transport, TransportOpts),
+    link(Pid),
     {ok, #{'ID' := ID}} = eetcd_lease:grant(?MODULE, 5),
     {ok, _Pid2} = eetcd_lease:keep_alive(?MODULE, ID),
     {ok, #state{prefix = Prefix, lease_id = ID}}.


### PR DESCRIPTION
If the `ekka_cluster_etcd` process itself dies, the `eetcd` client
will keep running, and when the supervisor tries to restart
`ekka_cluster_etcd`, it'll fail because the client is already running.

By linking to it, we'll ensure it gets killed together and the
supervisor may restart it successfully.

```
2022-02-08T14:57:06.452469+00:00 [error] Supervisor: {local,ekka_cluster_sup}. Context: start_error. Reason: {{badmatch,{error,[{{"etcd0.int.thalesmg",2379},already_started}]}},[{ekka_cluster_etcd,init,1,[{file,"/emqx/deps/ekka/src/ekka_cluster_etcd.erl"},{line,337}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,423}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,390}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}. Offender: id=ekka_cluster_etcd,pid={restarting,<0.2211.0>}.
```