### PR TITLE
fix: unlock on lock error

### DIFF
--- a/src/ekka_autocluster.erl
+++ b/src/ekka_autocluster.erl
@@ -78,15 +78,16 @@ maybe_run_again(App) ->
 discover_and_join() ->
     with_strategy(
       fun(Mod, Options) ->
-        case Mod:lock(Options) of
+        try Mod:lock(Options) of
             ok ->
-                discover_and_join(Mod, Options),
-                log_error("Unlock", Mod:unlock(Options));
+                discover_and_join(Mod, Options);
             ignore ->
                 timer:sleep(rand:uniform(3000)),
                 discover_and_join(Mod, Options);
             {error, Reason} ->
                 ?LOG(error, "AutoCluster stopped for lock error: ~p", [Reason])
+        after
+            log_error("Unlock", Mod:unlock(Options))
         end
       end).
 


### PR DESCRIPTION
Occasionally, the cluster strategy lock may raise some error, like
timing out during a `gen_server:call`.  In this case, it might
deadlock and prevent the lock from being acquired again.

```
Ekka(AutoCluster): Discover error: {timeout,{gen_server,call,[ekka_cluster_etcd,lock,5000]}}, [{gen_server,call,3,[{file,"gen_server.erl"},{line,247}]},{ekka_autocluster,'-discover_and_join/0-fun-0-',2,[{file,"/emqx/deps/ekka/src/ekka_autocluster.erl"},{line,81}]},{ekka_autocluster,'-run/1-fun-0-',1,[{file,"/emqx/deps/ekka/src/ekka_autocluster.erl"},{line,48}]}]
```
This can prevent or hinder the cluster from forming.