### PR TITLE
fix: ensure node is registered during autocluster

### DIFF
--- a/src/ekka_cluster_etcd.erl
+++ b/src/ekka_cluster_etcd.erl
@@ -19,6 +19,8 @@
 
 -behaviour(gen_server).
 
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
 -export([ discover/1
         , lock/1
         , unlock/1
@@ -135,6 +137,7 @@ v2_unlock(Options) ->
     end.
 
 v2_register(Options) ->
+    ?tp(ekka_cluster_etcd_v2_register, #{}),
     case etcd_set_node_key(Options) of
         {ok, _Response} ->
             ensure_node_ttl(Options);
@@ -277,6 +280,7 @@ v3_unlock(_) ->
     end.
 
 v3_register(#state{prefix = Prefix ,lease_id = ID}) ->
+    ?tp(ekka_cluster_etcd_v3_register, #{prefix => Prefix, lease_id => ID}),
     Context = v3_node_context(Prefix, ID),
     case eetcd_kv:put(Context) of
         {ok, _Response} ->

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -20,6 +20,7 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(DNS_OPTIONS, [{name, "localhost"},
                       {app, "ct"}
@@ -190,6 +191,56 @@ t_core_node_discovery_callback(_Config) ->
         ok = ekka_ct:stop_slave(N1),
         ok = ekka_ct:stop_slave(N2)
     end.
+
+%%--------------------------------------------------------------------
+%% Misc tests
+%%--------------------------------------------------------------------
+
+t_run_again_when_not_registered(_Config) ->
+    application:set_env(ekka, test_etcd_nodes, ["n1@127.0.0.1", "ct@127.0.0.1"]),
+    {ok, _} = start_etcd_server(2379),
+    N1 = ekka_ct:start_slave(ekka, n1),
+    ?check_trace(
+       #{timetrap => 30_000},
+       try
+           ok = ekka_ct:wait_running(N1),
+           ok = set_app_env(N1, {etcd, ?ETCD_OPTIONS}),
+           ok = rpc:call(N1, meck, new, [ekka_cluster_etcd,
+                                         [non_strict, passthrough,
+                                          no_history, no_link]]),
+           ok = rpc:call(
+                  N1, meck, expect,
+                  [ekka_cluster_etcd, discover,
+                   [{['_'], meck:seq(
+                              [ %% first try; fail
+                                meck:val({ok, []})
+                                %% checking if registered; fail
+                              , meck:val({ok, []})
+                                %% work afterwards
+                              , meck:passthrough()
+                              ])}]]),
+           _ = rpc:call(N1, ekka, autocluster, []),
+           ok = wait_for_node(N1),
+           ok = ekka:force_leave(N1)
+       after
+           ok = stop_etcd_server(2379),
+           application:unset_env(ekka, test_etcd_nodes),
+           ok = ekka_ct:stop_slave(N1)
+       end,
+       fun(Trace) ->
+               ct:pal("trace: ~100p~n", [Trace]),
+               ?assert(
+                  ?strict_causality(
+                     #{ ?snk_kind       := ekka_maybe_run_app_again
+                      , node_registered := false
+                      }
+                    , #{ ?snk_kind       := ekka_maybe_run_app_again
+                       , node_registered := true
+                       }
+                    , Trace
+                    )),
+               ok
+       end).
 
 %%--------------------------------------------------------------------
 %% Helper functions


### PR DESCRIPTION
Sometimes, for still unknown reasons, core nodes can successfully join
the ekka/mria cluster, but fail to announce themselves to the service
discovery.  This leads to an incorrect value reported by the core node
discovery callback, which relies on the announce mechanism. In turn,
that prevents replicants from joining the cluster, because they check
that announced list against the db nodes reported by mria, and refuse
to accept such list because of the "unknown" nodes from mria.

So, we make the autocluster also check if the node is successfully
registered and, if not, retry to discover and join the cluster,
hopefully announcing the node correctly in the process.

Example:

```
2022-03-08T14:21:48.129201-03:00 [error] '$kind': mria_lb_core_discovery_divergent_cluster, line: 171, mfa: mria_lb:list_core_nodes/1, node: 'emqx@emqx-3.int.thalesmg', previous_cores: [], returned_cores: ['emqx@emqx-2.int.thalesmg'], unknown_nodes: ['emqx@emqx-0.int.thalesmg','emqx@emqx-1.int.thalesmg']

  ... after manually registering emqx-2

2022-03-08T16:05:25.087425-03:00 [error] '$kind': mria_lb_core_discovery_divergent_cluster, line: 171, mfa: mria_lb:list_core_nodes/1, node: 'emqx@emqx-3.int.thalesmg', previous_cores: [], returned_cores: ['emqx@emqx-1.int.thalesmg','emqx@emqx-2.int.thalesmg'], unknown_nodes: ['emqx@emqx-0.int.thalesmg']
```

```elixir
iex(emqx@emqx-2.int.thalesmg)12> :erpc.multicall(nodes, :ekka_autocluster, :core_node_discovery_callback, [], 5_000)
[
  ok: [:"emqx@emqx-2.int.thalesmg"],
  ok: [:"emqx@emqx-2.int.thalesmg"],
  ok: [:"emqx@emqx-2.int.thalesmg"]
]

iex(emqx@emqx-2.int.thalesmg)17> :mria_mnesia.db_nodes
[:"emqx@emqx-1.int.thalesmg", :"emqx@emqx-2.int.thalesmg",
 :"emqx@emqx-0.int.thalesmg"]
```