### PR TITLE
chore: bump mria -> 0.2.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
         {eetcd, {git, "https://github.com/zhongwencool/eetcd", {tag, "v0.3.4"}}},
         {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "0.17.1"}}},
-        {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.1"}}}
+        {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.2"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,


### PR DESCRIPTION
- does not start rlog supervision tree if backend is mnesia
- fix return core list when calling `cluster_nodes(cores)` from a
  replicant.
- configure shard transport per shard.
- fix: autoheal considers only core nodes.
- fix: membership does not include replicant nodes.