### PR TITLE
fix: ensure etcd connection is closed at startup

### DIFF
--- a/src/ekka_cluster_etcd.erl
+++ b/src/ekka_cluster_etcd.erl
@@ -338,6 +338,13 @@ init(Options) ->
         [] -> {tcp, []};
         [SSL] -> SSL
     end,
+    %% At the time of writing, the etcd connection process does not
+    %% close when this process dies.  So, when this processes is
+    %% restarted by its supervisor, the `eetcd:open' call fails with
+    %% `{error,[{{"localhost",2379},already_started}]}'.  This ensures
+    %% that no connection with this name exists before opening it
+    %% (again).
+    eetcd:close(?MODULE),
     {ok, _Pid} = eetcd:open(?MODULE, Hosts, Transport, TransportOpts),
     {ok, #{'ID' := ID}} = eetcd_lease:grant(?MODULE, 5),
     {ok, _Pid2} = eetcd_lease:keep_alive(?MODULE, ID),

--- a/test/ekka_ct.erl
+++ b/test/ekka_ct.erl
@@ -96,3 +96,13 @@ vals_to_csv(L) ->
 
 setenv(Node, Env) ->
     [rpc:call(Node, application, set_env, [App, Key, Val]) || {App, Key, Val} <- Env].
+
+is_tcp_server_available(Host, Port) ->
+    Timeout = 15_000,
+    case gen_tcp:connect(Host, Port, [], Timeout) of
+        {ok, Socket} ->
+            gen_tcp:close(Socket),
+            true;
+        {error, _} ->
+            false
+    end.


### PR DESCRIPTION
If the `ekka_cluster_etcd` process itself dies, the `eetcd` client
will keep running, and when the supervisor tries to restart
`ekka_cluster_etcd`, it'll fail because the client is already running.

By closing any possibly existing connections before connecting again,
the supervisor may restart it successfully.

```
2022-02-08T14:57:06.452469+00:00 [error] Supervisor: {local,ekka_cluster_sup}. Context: start_error. Reason: {{badmatch,{error,[{{"etcd0.int.thalesmg",2379},already_started}]}},[{ekka_cluster_etcd,init,1,[{file,"/emqx/deps/ekka/src/ekka_cluster_etcd.erl"},{line,337}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,423}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,390}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}. Offender: id=ekka_cluster_etcd,pid={restarting,<0.2211.0>}.
```