### PR TITLE
fix(autocluster): retry autocluster if there are nodes outside cluster

### DIFF
--- a/src/ekka.appup.src
+++ b/src/ekka.appup.src
@@ -1,10 +1,15 @@
 %% -*- mode: erlang -*-
 {VSN,
-  [{"0.8.1.8",
-    [{load_module,ekka_mnesia,brutal_purge,soft_purge,[]}
+  [{"0.8.1.9",
+    [{load_module,ekka_autocluster,brutal_purge,soft_purge,[]}
+    ]},
+   {"0.8.1.8",
+    [{load_module,ekka_autocluster,brutal_purge,soft_purge,[]},
+     {load_module,ekka_mnesia,brutal_purge,soft_purge,[]}
     ]},
    {"0.8.1.7",
-    [{load_module,ekka_locker,brutal_purge,soft_purge,[]},
+    [{load_module,ekka_autocluster,brutal_purge,soft_purge,[]},
+     {load_module,ekka_locker,brutal_purge,soft_purge,[]},
      {load_module,ekka_mnesia,brutal_purge,soft_purge,[]}
     ]},
    {<<"0\\.8\\.1\\.[3-6]">>,
@@ -44,11 +49,16 @@
      {load_module,ekka_locker,brutal_purge,soft_purge,[]},
      {load_module,ekka_httpc,brutal_purge,soft_purge,[]},
      {load_module,ekka_mnesia,brutal_purge,soft_purge,[]}]}],
-  [{"0.8.1.8",
-    [{load_module,ekka_mnesia,brutal_purge,soft_purge,[]}
+  [{"0.8.1.9",
+    [{load_module,ekka_autocluster,brutal_purge,soft_purge,[]}
+    ]},
+   {"0.8.1.8",
+    [{load_module,ekka_autocluster,brutal_purge,soft_purge,[]},
+     {load_module,ekka_mnesia,brutal_purge,soft_purge,[]}
     ]},
    {"0.8.1.7",
-    [{load_module,ekka_locker,brutal_purge,soft_purge,[]},
+    [{load_module,ekka_autocluster,brutal_purge,soft_purge,[]},
+     {load_module,ekka_locker,brutal_purge,soft_purge,[]},
      {load_module,ekka_mnesia,brutal_purge,soft_purge,[]}
     ]},
    {<<"0\\.8\\.1\\.[3-6]">>,

--- a/test/mod_etcd.erl
+++ b/test/mod_etcd.erl
@@ -21,11 +21,18 @@
 -export([do/1]).
 
 do(_Req = #mod{method = "GET", request_uri = "/v2/keys/" ++ _Uri}) ->
-    Response = {200, "{\"node\": {\"nodes\": [{\"key\": \"cl/ct@127.0.0.1\"}]}}"},
+    Nodes = application:get_env(ekka, test_etcd_nodes, ["ct@127.0.0.1"]),
+    Body = #{ <<"node">> =>
+                  #{ <<"nodes">> =>
+                         lists:map(fun(N) ->
+                                           #{<<"key">> => list_to_binary("cl/" ++ N)}
+                                   end,
+                                   Nodes)
+                   }
+            },
+    Response = {200, binary_to_list(jiffy:encode(Body))},
     {proceed, [{response, Response}]};
-
 do(_Req = #mod{request_uri = "/v2/keys/" ++ _Uri}) ->
     {proceed, [{response, {200, "{\"errorCode\": 0}"}}]};
 
 do(Req) -> {proceed, Req#mod.data}.
-


### PR DESCRIPTION
To avoid split-brain scenarios, we retry the autocluster procedure if
there still nodes being discovered outside the cluster.