### PR TITLE
fix(autocluster): retry autocluster if there are nodes outside cluster

### DIFF
--- a/src/ekka_autocluster.erl
+++ b/src/ekka_autocluster.erl
@@ -30,6 +30,9 @@
 -define(LOG(Level, Format, Args),
         logger:Level("Ekka(AutoCluster): " ++ Format, Args)).
 
+%% ms
+-define(DISCOVER_AND_JOIN_RETRY_INTERVAL, 5000).
+
 -spec(enabled() -> boolean()).
 enabled() ->
     case ekka:env(cluster_discovery) of
@@ -46,15 +49,17 @@ run(App) ->
             spawn(fun() ->
                       group_leader(whereis(init), self()),
                       wait_application_ready(App, 10),
-                      try
-                          discover_and_join()
-                      catch
-                          _:Error:Stacktrace ->
-                              ?LOG(error, "Discover error: ~p~n~p", [Error, Stacktrace])
-                      after
-                          release_lock(App)
-                      end,
-                      maybe_run_again(App)
+                      JoinResult =
+                        try
+                            discover_and_join()
+                        catch
+                            _:Error:Stacktrace ->
+                                ?LOG(error, "Discover error: ~p~n~p", [Error, Stacktrace]),
+                                error
+                        after
+                            release_lock(App)
+                        end,
+                      maybe_run_again(App, JoinResult)
                   end);
         failed -> ignore
     end.
@@ -68,19 +73,25 @@ wait_application_ready(App, Retries) ->
                  wait_application_ready(App, Retries - 1)
     end.
 
-maybe_run_again(App) ->
+maybe_run_again(App, JoinResult) ->
     %% Check if the node joined cluster?
-    InCluster = mria_mnesia:is_node_in_cluster(),
+    NodeInCluster = mria_mnesia:is_node_in_cluster(),
+    %% Possibly there are nodes outside the cluster; keep trying if
+    %% so.
+    NoNodesOutside = JoinResult =:= ok,
     Registered = is_node_registered(),
     ?tp(ekka_maybe_run_app_again,
         #{ app => App
-         , node_in_cluster => InCluster
-         , node_registered => Registered
+         , node_in_cluster  => NodeInCluster
+         , node_registered  => Registered
+         , no_nodes_outside => NoNodesOutside
          }),
-    case InCluster andalso Registered of
+    case NodeInCluster andalso Registered andalso NoNodesOutside of
         true  -> ok;
         false ->
-            timer:sleep(5000),
+            ?LOG(warning, "discovery did not succeed; retrying in ~p ms",
+                 [?DISCOVER_AND_JOIN_RETRY_INTERVAL]),
+            timer:sleep(?DISCOVER_AND_JOIN_RETRY_INTERVAL),
             run(App)
     end.
 
@@ -90,12 +101,15 @@ discover_and_join() ->
       fun(Mod, Options) ->
         try Mod:lock(Options) of
             ok ->
-                discover_and_join(Mod, Options);
+                Res = discover_and_join(Mod, Options),
+                log_error("Unlock", Mod:unlock(Options)),
+                Res;
             ignore ->
                 timer:sleep(rand:uniform(3000)),
                 discover_and_join(Mod, Options);
             {error, Reason} ->
-                ?LOG(error, "AutoCluster stopped for lock error: ~p", [Reason])
+                ?LOG(error, "AutoCluster stopped for lock error: ~p", [Reason]),
+                error
         after
             log_error("Unlock", Mod:unlock(Options))
         end
@@ -141,18 +155,38 @@ discover_and_join(Mod, Options) ->
     case Mod:discover(Options) of
         {ok, Nodes} ->
             ?tp(ekka_autocluster_discover_and_join_ok, #{mod => Mod, nodes => Nodes}),
-            maybe_join([N || N <- Nodes, ekka_node:is_aliving(N)]),
-            log_error("Register", Mod:register(Options));
+            {AliveNodes, DeadNodes} = lists:partition(
+                                        fun ekka_node:is_aliving/1,
+                                        Nodes),
+            Res = maybe_join(AliveNodes),
+            ?LOG(debug, "join result: ~p", [Res]),
+            log_error("Register", Mod:register(Options)),
+            case DeadNodes of
+                [] ->
+                    ?LOG(info, "no discovered nodes outside cluster", []),
+                    ok;
+                [_ | _] ->
+                    ?LOG(warning, "discovered nodes outside cluster: ~p", [DeadNodes]),
+                    error
+            end;
         {error, Reason} ->
-            ?LOG(error, "Discovery error: ~p", [Reason])
+            ?LOG(error, "Discovery error: ~p", [Reason]),
+            error
     end.
 
 maybe_join([]) ->
     ignore;
-maybe_join(Nodes) ->
-    case mria_mnesia:is_node_in_cluster() of
-        true  -> ignore;
-        false -> join_with(find_oldest_node(Nodes))
+maybe_join(Nodes0) ->
+    Nodes = lists:usort(Nodes0),
+    KnownNodes = lists:usort(mria_mnesia:cluster_nodes(all)),
+    case Nodes =:= KnownNodes of
+        true  ->
+            ?LOG(info, "all discovered nodes already in cluster; ignoring", []),
+            ignore;
+        false ->
+            OldestNode = find_oldest_node(Nodes),
+            ?LOG(info, "joining with ~p", [OldestNode]),
+            join_with(OldestNode)
     end.
 
 join_with(false) ->

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -20,6 +20,7 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(DNS_OPTIONS, [{name, "localhost"},
@@ -60,6 +61,55 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
+init_per_testcase(t_autocluster_retry_when_missing_nodes, Config) ->
+    _ = inets:start(),
+    ok = application:set_env(ekka, cluster_name, ekka),
+    ok = application:set_env(ekka, cluster_enable, true),
+    ok = ekka:start(),
+    application:set_env(ekka, test_etcd_nodes,
+                        ["n1@127.0.0.1", "ct@127.0.0.1", "n2@127.0.0.1"]),
+    {ok, _} = start_etcd_server(2379),
+    Nodes = [ekka_ct:start_slave(ekka, N) || N <- [n1, n2]],
+    lists:foreach(
+      fun(Node) ->
+              ok = set_app_env(Node, {etcd, ?ETCD_OPTIONS}),
+              ok = setup_cover(Node),
+              ekka:leave()
+      end,
+      Nodes),
+    ok = set_app_env(node(), {etcd, ?ETCD_OPTIONS}),
+    [ {nodes, Nodes}
+    | Config];
+init_per_testcase(t_core_node_discovery_callback, Config) ->
+    _ = inets:start(),
+    ok = application:set_env(ekka, cluster_name, ekka),
+    ok = application:set_env(ekka, cluster_enable, true),
+    ok = ekka:start(),
+    {ok, _} = start_etcd_server(2379),
+    application:set_env(ekka, test_etcd_nodes, [ "ct@127.0.0.1"
+                                               , "n1@127.0.0.1"
+                                               , "n2@127.0.0.1"
+                                               ]),
+    N1 = ekka_ct:start_slave(ekka, n1, [ {mria, db_backend, rlog}
+                                       ]),
+    N2 = ekka_ct:start_slave(ekka, n2, [ {mria, db_backend, rlog}
+                                       , {mria, node_role, replicant}
+                                       ]),
+    [ {nodes, [N1, N2]}
+    | Config];
+init_per_testcase(t_run_again_when_not_registered, Config) ->
+    _ = inets:start(),
+    ok = application:set_env(ekka, cluster_name, ekka),
+    ok = application:set_env(ekka, cluster_enable, true),
+    ok = ekka:start(),
+    {ok, _} = start_etcd_server(2379),
+    application:set_env(ekka, test_etcd_nodes, [ "ct@127.0.0.1"
+                                               , "n1@127.0.0.1"
+                                               ]),
+    N1 = ekka_ct:start_slave(ekka, n1, [ {mria, db_backend, rlog}
+                                       ]),
+    [ {nodes, [N1]}
+    | Config];
 init_per_testcase(_TestCase, Config) ->
     _ = inets:start(),
     ok = application:set_env(ekka, cluster_name, ekka),
@@ -67,9 +117,35 @@ init_per_testcase(_TestCase, Config) ->
     ok = ekka:start(),
     Config.
 
-end_per_testcase(TestCase, Config) ->
+end_per_testcase(t_autocluster_retry_when_missing_nodes, Config) ->
+    [N1, N2] = ?config(nodes, Config),
+    ekka:force_leave(N1),
+    ekka:force_leave(N2),
+    ok = ekka_ct:stop_slave(N1),
+    ok = ekka_ct:stop_slave(N2),
+    ok = stop_etcd_server(2379),
+    application:unset_env(ekka, test_etcd_nodes),
+    catch meck:unload(ekka_node),
+    ok;
+end_per_testcase(t_core_node_discovery_callback, Config) ->
+    [N1, N2] = ?config(nodes, Config),
+    ekka:force_leave(N1),
+    ekka:force_leave(N2),
+    ok = ekka_ct:stop_slave(N1),
+    ok = ekka_ct:stop_slave(N2),
+    ok = stop_etcd_server(2379),
+    application:unset_env(ekka, test_etcd_nodes),
+    ok;
+end_per_testcase(t_run_again_when_not_registered, Config) ->
+    [N1] = ?config(nodes, Config),
+    ekka:force_leave(N1),
+    ok = ekka_ct:stop_slave(N1),
+    ok = stop_etcd_server(2379),
+    application:unset_env(ekka, test_etcd_nodes),
+    ok;
+end_per_testcase(TestCase, _Config) ->
     ekka_ct:cleanup(TestCase),
-    Config.
+    ok.
 
 %%--------------------------------------------------------------------
 %% Autocluster via 'static' strategy
@@ -169,6 +245,47 @@ t_autocluster_k8s_lock_failure(_Config) ->
         ok = ekka_ct:stop_slave(N1)
     end.
 
+t_autocluster_retry_when_missing_nodes(Config) ->
+    Nodes = [N1, N2] = ?config(nodes, Config),
+    ThisNode = node(),
+    assert_cluster_nodes_equal([N1], N1),
+    assert_cluster_nodes_equal([N2], N2),
+    assert_cluster_nodes_equal([ThisNode], ThisNode),
+
+    %% Make the two nodes cluster with each other, but fail to
+    %% cluster with master.  Check if autocluster is tried again.
+    ct:pal("testing cluster with failure"),
+    mock_autocluster_failure(Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ok = ekka_ct:wait_running(Node)
+      end,
+      Nodes),
+    rpc:call(N1, ekka, autocluster, []),
+    rpc:call(N2, ekka, autocluster, []),
+    ekka:autocluster(),
+    timer:sleep(10000),
+    ok = cover:flush(Nodes),
+    {ok, Stats} = cover:analyse(ekka_autocluster, calls, function),
+    [TimesCalled] = [TimesCalled ||
+                        {{ekka_autocluster,run,1}, TimesCalled} <- Stats],
+    ?assert(TimesCalled > length([ThisNode | Nodes]), Stats),
+    assert_cluster_nodes_equal([N1, N2], N1),
+    assert_cluster_nodes_equal([N1, N2], N2),
+    assert_cluster_nodes_equal([ThisNode], ThisNode),
+    %% Now remove the mock; the cluster should eventually heal
+    %% itself.
+    ok = rpc:call(N1, meck, unload, [ekka_node]),
+    ok = rpc:call(N2, meck, unload, [ekka_node]),
+    meck:unload(ekka_node),
+    ct:pal("testing cluster without failure"),
+    timer:sleep(10000),
+    AllNodes = [ThisNode, N1, N2],
+    assert_cluster_nodes_equal(AllNodes, N1),
+    assert_cluster_nodes_equal(AllNodes, N2),
+    assert_cluster_nodes_equal(AllNodes, ThisNode),
+    ok.
+
 %%--------------------------------------------------------------------
 %% Autocluster via 'mcast' strategy
 
@@ -206,49 +323,31 @@ t_autocluster_mcast_lock_failure(_Config) ->
 %%--------------------------------------------------------------------
 %% Core node discovery callback
 
-t_core_node_discovery_callback(_Config) ->
-    {ok, _} = start_etcd_server(2379),
-    application:set_env(ekka, test_etcd_nodes, [ "ct@127.0.0.1"
-                                               , "n1@127.0.0.1"
-                                               , "n2@127.0.0.1"
-                                               ]),
-    N1 = ekka_ct:start_slave(ekka, n1, [ {mria, db_backend, rlog}
-                                       ]),
-    N2 = ekka_ct:start_slave(ekka, n2, [ {mria, db_backend, rlog}
-                                       , {mria, node_role, replicant}
-                                       ]),
-    try
-        ok = ekka_ct:wait_running(N1),
-        ok = ekka_ct:wait_running(N2),
-        ok = set_app_env(N1, {etcd, ?ETCD_OPTIONS}),
-        ok = set_app_env(N2, {etcd, ?ETCD_OPTIONS}),
-        _ = rpc:call(N1, ekka, autocluster, []),
-        _ = rpc:call(N2, ekka, autocluster, []),
-        ok = wait_for_node(N1),
-        %% filtering the core nodes is done by mria
-        ?assertEqual(
-           ['ct@127.0.0.1', 'n1@127.0.0.1', 'n2@127.0.0.1'],
-           erpc:call(N2, ekka_autocluster, core_node_discovery_callback, [], 5000)
-          ),
-        ok = ekka:force_leave(N1)
-    after
-        ok = stop_etcd_server(2379),
-        application:unset_env(ekka, test_etcd_nodes),
-        ok = ekka_ct:stop_slave(N1),
-        ok = ekka_ct:stop_slave(N2)
-    end.
+t_core_node_discovery_callback(Config) ->
+    [N1, N2] = ?config(nodes, Config),
+    ok = ekka_ct:wait_running(N1),
+    ok = ekka_ct:wait_running(N2),
+    ok = set_app_env(N1, {etcd, ?ETCD_OPTIONS}),
+    ok = set_app_env(N2, {etcd, ?ETCD_OPTIONS}),
+    _ = rpc:call(N1, ekka, autocluster, []),
+    _ = rpc:call(N2, ekka, autocluster, []),
+    ok = wait_for_node(N1),
+    %% filtering the core nodes is done by mria
+    ?assertEqual(
+       ['ct@127.0.0.1', 'n1@127.0.0.1', 'n2@127.0.0.1'],
+       erpc:call(N2, ekka_autocluster, core_node_discovery_callback, [], 5000)
+      ),
+    ok.
 
 %%--------------------------------------------------------------------
 %% Misc tests
 %%--------------------------------------------------------------------
 
-t_run_again_when_not_registered(_Config) ->
-    application:set_env(ekka, test_etcd_nodes, ["n1@127.0.0.1", "ct@127.0.0.1"]),
-    {ok, _} = start_etcd_server(2379),
-    N1 = ekka_ct:start_slave(ekka, n1),
+t_run_again_when_not_registered(Config) ->
+    [N1] = ?config(nodes, Config),
     ?check_trace(
        #{timetrap => 30_000},
-       try
+       begin
            ok = ekka_ct:wait_running(N1),
            ok = set_app_env(N1, {etcd, ?ETCD_OPTIONS}),
            ok = rpc:call(N1, meck, new, [ekka_cluster_etcd,
@@ -267,11 +366,7 @@ t_run_again_when_not_registered(_Config) ->
                               ])}]]),
            _ = rpc:call(N1, ekka, autocluster, []),
            ok = wait_for_node(N1),
-           ok = ekka:force_leave(N1)
-       after
-           ok = stop_etcd_server(2379),
-           application:unset_env(ekka, test_etcd_nodes),
-           ok = ekka_ct:stop_slave(N1)
+           ok
        end,
        fun(Trace) ->
                ct:pal("trace: ~100p~n", [Trace]),
@@ -355,3 +450,37 @@ assert_unlocked(StrategyMod, Node) ->
         Timeout -> error(failed_to_unlock)
     end,
     ok.
+
+setup_cover(Node) ->
+    SrcPath = proplists:get_value(source, ekka_autocluster:module_info(compile)),
+    CompileOpts = proplists:get_value(options, ekka_autocluster:module_info(compile)),
+    rpc:call(Node, cover, start, []),
+    cover:compile_module(SrcPath, CompileOpts),
+    ok.
+
+mock_autocluster_failure(Nodes) ->
+    ThisNode = node(),
+    lists:foreach(
+      fun(Node) ->
+              ok = rpc:call(Node, meck, new,
+                            [ekka_node, [no_link, passthrough, no_history, non_strict]]),
+              ok = rpc:call(Node, meck, expect,
+                            [ekka_node, is_aliving,
+                             fun(N) ->
+                                     N =/= ThisNode
+                             end])
+      end,
+      Nodes),
+    ok = meck:new(ekka_node, [no_link, passthrough, no_history, non_strict]),
+    ok = meck:expect(ekka_node, is_aliving,
+                     fun(N) ->
+                             N =:= ThisNode
+                     end),
+    ok.
+
+assert_cluster_nodes_equal(ExpectedNodes0, Node) ->
+    ct:pal("checking cluster nodes on ~p", [Node]),
+    ExpectedNodes = lists:usort(ExpectedNodes0),
+    Results0 = rpc:call(Node, mria_mnesia, cluster_nodes, [all]),
+    Results = lists:usort(Results0),
+    ?assertEqual(ExpectedNodes, Results).

--- a/test/mod_etcd.erl
+++ b/test/mod_etcd.erl
@@ -32,7 +32,6 @@ do(_Req = #mod{method = "GET", request_uri = "/v2/keys/" ++ _Uri}) ->
             },
     Response = {200, binary_to_list(jiffy:encode(Body))},
     {proceed, [{response, Response}]};
-
 do(_Req = #mod{request_uri = "/v2/keys/" ++ _Uri}) ->
     {proceed, [{response, {200, "{\"errorCode\": 0}"}}]};
 


### PR DESCRIPTION
To avoid split-brain scenarios, we retry the autocluster procedure if
there still nodes being discovered outside the cluster.

Port of #158 .