### PR TITLE
chore: bump mria -> 0.2.5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
         {eetcd, {git, "https://github.com/zhongwencool/eetcd", {tag, "v0.3.4"}}},
         {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.0"}}},
-        {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.4"}}}
+        {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.5"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,


### PR DESCRIPTION
- ~~do not wait on shard during transaction.~~
- reduces some message log levels about waiting for shards to
  debug on cores.

https://github.com/emqx/mria/pull/84
https://github.com/emqx/mria/pull/86