### PR TITLE
chore: upgrade mria to 0.2.16 to support mria:dirty_update_counter/{2,3}

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
         {eetcd, {git, "https://github.com/zhongwencool/eetcd", {tag, "v0.3.4"}}},
         {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.0"}}},
-        {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.15"}}}
+        {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.16"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,


### PR DESCRIPTION
see: https://github.com/emqx/mria/pull/109