### PR TITLE
chore: bump mria to 0.4.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
         {eetcd, {git, "https://github.com/zhongwencool/eetcd", {tag, "v0.3.4"}}},
         {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.0"}}},
-        {mria, {git, "https://github.com/emqx/mria", {tag, "0.4.0"}}}
+        {mria, {git, "https://github.com/emqx/mria", {tag, "0.4.1"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,


### PR DESCRIPTION
no functional changes, there are pre-built binary packages for more platforms