### PR TITLE
refactor: remove references to autoclean

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,26 +266,6 @@ Cuttlefish style config:
 cluster.autoheal = on
 ```
 
-## Node down and Autoclean
-
-### Autoclean Design
-
-A down node will be removed from the cluster if autoclean is enabled.
-
-### Enable autoclean
-
-Erlang config:
-
-```
-{cluster_autoclean, 60000},
-```
-
-Cuttlefish style config:
-
-```
-cluster.autoclean = 5m
-```
-
 ## Lock Service
 
 Ekka implements a simple distributed lock service in 0.3 release. The Lock APIs:

--- a/data/app.etcd.config
+++ b/data/app.etcd.config
@@ -1,5 +1,4 @@
 [{ekka,[{cluster_autoheal,true},
-        {cluster_autoclean,300000},
         {cluster_name,ekka},
         {cluster_discovery,{etcd,[{server,["http://127.0.0.1:2379"]},
                                   {prefix,"ekkacluster"},

--- a/data/app.mcast.config
+++ b/data/app.mcast.config
@@ -1,6 +1,5 @@
 [{ekka, [
   {cluster_autoheal,true},
-  {cluster_autoclean,300000},
   {cluster_name,ekka},
   {cluster_discovery, {mcast, [
     {addr,{239,192,0,1}},

--- a/etc/ekka.conf.example
+++ b/etc/ekka.conf.example
@@ -34,17 +34,6 @@ cluster.discovery = manual
 ## Default: 15 Seconds
 cluster.autoheal = 15s
 
-## Autoclean down node. A down node will be removed from the cluster
-## if this value > 0.
-##
-## Value: Duration
-## -h: hour, e.g. '2h' for 2 hours
-## -m: minute, e.g. '5m' for 5 minutes
-## -s: second, e.g. '30s' for 30 seconds
-##
-## Default: 5m
-cluster.autoclean = 5m
-
 ## Specify the erlang distributed protocol for the cluster.
 ##
 ## Value: Enum
@@ -189,4 +178,3 @@ cluster.proto_dist = inet_tcp
 ##
 ## Value: String
 ## cluster.k8s.suffix = pod.cluster.local
-

--- a/etc/ekka.config.example
+++ b/etc/ekka.config.example
@@ -1,7 +1,6 @@
 [{ekka, [
   {cluster_name, ekka},
   {cluster_autoheal, true},
-  {cluster_autoclean, 60000},
   {proto_dist, inet_tcp},
 
 %% Clustering via static node list

--- a/priv/ekka.schema
+++ b/priv/ekka.schema
@@ -21,11 +21,6 @@
   {datatype, atom}
 ]}.
 
-%% @doc Clean down node from the cluster
-{mapping, "cluster.autoclean", "ekka.cluster_autoclean", [
-  {datatype, {duration, ms}}
-]}.
-
 %% @doc Cluster autoheal
 {mapping, "cluster.autoheal", "ekka.cluster_autoheal", [
   {datatype, [flag, {duration, ms}]},

--- a/test/ekka_SUITE_data/ekka.config
+++ b/test/ekka_SUITE_data/ekka.config
@@ -1,5 +1,4 @@
 {cluster_name, ekka}.
 {cluster_autoheal, true}.
-{cluster_autoclean, 60000}.
 {proto_dist, inet_tcp}.
 {cluster_discovery, {manual, []}}.


### PR DESCRIPTION
This option is no longer used by ekka, as it has been moved to mria.