### PR TITLE
chore: bump mria -> 0.5.8

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -9,16 +9,16 @@ jobs:
         strategy:
           matrix:
             os:
-              - ubuntu20.04
+              - ubuntu22.04
             otp:
-              - 24.3.4.2-3
+              - 25.3.2-1
             elixir:
-              - 1.13.4
+              - 1.14.5
             arch:
               - amd64
 
         container:
-            image: ghcr.io/emqx/emqx-builder/5.0-33:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
+            image: ghcr.io/emqx/emqx-builder/5.1-3:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
 
         steps:
         - uses: actions/checkout@v2

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
         {eetcd, {git, "https://github.com/zhongwencool/eetcd", {tag, "v0.3.4"}}},
         {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.0"}}},
-        {mria, {git, "https://github.com/emqx/mria", {tag, "0.5.7"}}}
+        {mria, {git, "https://github.com/emqx/mria", {tag, "0.5.8"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,

--- a/test/ekka_autocluster_SUITE.erl
+++ b/test/ekka_autocluster_SUITE.erl
@@ -399,6 +399,8 @@ t_run_again_when_not_registered(Config) ->
                               ])}]]),
            _ = rpc:call(N1, ekka, autocluster, []),
            ok = wait_for_node(N1),
+           %% to avoid flakiness
+           ?block_until(#{?snk_kind := ekka_maybe_run_app_again, node_registered := true}, 5_000),
            ok
        end,
        fun(Trace) ->


### PR DESCRIPTION
https://github.com/emqx/erlang-rocksdb/releases/tag/1.8.0-emqx-1

also bumps builder images and distros

will tag 0.15.6