### PR TITLE
chore: bump mria to 0.6.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
         {eetcd, {git, "https://github.com/zhongwencool/eetcd", {tag, "v0.3.4"}}},
         {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.0"}}},
-        {mria, {git, "https://github.com/emqx/mria", {tag, "0.5.10"}}}
+        {mria, {git, "https://github.com/emqx/mria", {tag, "0.6.0"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,

--- a/src/ekka.app.src
+++ b/src/ekka.app.src
@@ -1,6 +1,6 @@
 {application, ekka,
  [{description, "Autocluster for EMQ X Broker"},
-  {vsn, "0.15.9"},
+  {vsn, "0.15.10"},
   {mod, {ekka_app,[]}},
   {registered,
    [ekka_sup,

--- a/src/ekka.appup.src
+++ b/src/ekka.appup.src
@@ -1,6 +1,6 @@
 %% -*-: erlang -*-
 
-{"0.15.9",
+{"0.15.10",
   [
     {<<"0\\.13\\.[0-1]">>, [
         {load_module,ekka_dist,brutal_purge,soft_purge,[]}


### PR DESCRIPTION
Also prepare `ekka` 0.15.10 release.