### PR TITLE
chore: upgrade to mria 0.8.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
         {eetcd, {git, "https://github.com/zhongwencool/eetcd", {tag, "v0.3.4"}}},
         {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.0"}}},
-        {mria, {git, "https://github.com/emqx/mria", {tag, "0.7.1"}}}
+        {mria, {git, "https://github.com/emqx/mria", {tag, "0.8.0"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,


### PR DESCRIPTION
Mria 0.8.0 release implements `mria:match_delete/2` function