### PR TITLE
feat(boot): allow to disable running mnesia boot phase

### DIFF
--- a/src/ekka.erl
+++ b/src/ekka.erl
@@ -96,9 +96,15 @@ start() ->
     ekka_boot:register_mria_callbacks(),
     {ok, _Apps} = application:ensure_all_started(ekka),
     ?tp(info, "Ekka is running", #{}),
-    ekka_boot:create_tables(),
+    maybe_create_tables(),
     ekka:exec_callback(start),
     ok.
+
+maybe_create_tables() ->
+    case env(boot_create_tables, true) of
+        true -> ekka_boot:create_tables();
+        false -> ok
+    end.
 
 -spec(stop() -> ok).
 stop() ->

--- a/test/ekka_SUITE.erl
+++ b/test/ekka_SUITE.erl
@@ -24,7 +24,6 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
--define(CONTENT_TYPE, "application/x-www-form-urlencoded").
 
 all() -> ekka_ct:all(?MODULE).
 

--- a/test/ekka_boot_SUITE.erl
+++ b/test/ekka_boot_SUITE.erl
@@ -52,3 +52,28 @@ t_register_mria_callbacks(_) ->
           , core_node_discovery
           ])
     end.
+
+t_create_tables_on(_) ->
+    _ = application:load(ekka_boot_testapp),
+    _ = application:load(ekka),
+    ok = ekka:start(),
+    try
+        ?assertMatch(Ts when is_integer(Ts), ekka_boot_testapp:booted())
+    after
+        ok = ekka:stop(),
+        ok = application:unload(ekka),
+        ok = application:unload(ekka_boot_testapp)
+    end.
+
+t_create_tables_off(_) ->
+    _ = application:load(ekka_boot_testapp),
+    _ = application:load(ekka),
+    ok = application:set_env(ekka, boot_create_tables, false),
+    ok = ekka:start(),
+    try
+        ?assertEqual(undefined, ekka_boot_testapp:booted())
+    after
+        ok = ekka:stop(),
+        ok = application:unload(ekka),
+        ok = application:unload(ekka_boot_testapp)
+    end.

--- a/test/ekka_boot_testapp.app
+++ b/test/ekka_boot_testapp.app
@@ -1,0 +1,8 @@
+{application,ekka_boot_testapp,
+             [{description,"Ekka Boot TestApp"},
+              {vsn,"0.1.0"},
+              {registered,[]},
+              {applications,[kernel,stdlib,ekka]},
+              {modules,[ekka_boot_testapp]},
+              {licenses,["Apache 2.0"]},
+              {maintainers,["EMQX Team <contact@emqx.io>"]}]}.

--- a/test/ekka_boot_testapp.erl
+++ b/test/ekka_boot_testapp.erl
@@ -1,0 +1,31 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(ekka_boot_testapp).
+
+-boot_mnesia({mnesia, [boot]}).
+
+-export([mnesia/1]).
+
+-export([booted/0]).
+
+%%
+
+mnesia(boot) ->
+    application:set_env(?MODULE, boot, erlang:system_time()).
+
+booted() ->
+    application:get_env(?MODULE, boot, undefined).


### PR DESCRIPTION
In situations where library users manage tables explicitly as part of applications' startup routines turning this feature off might help to greatly reduce the time it takes ekka to start.