### PR TITLE
fix: upgrade mria from 0.8.13 to 0.8.15.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{jsone, "1.9.0"},
         {eetcd, {git, "https://github.com/zhongwencool/eetcd", {tag, "v0.5.0"}}},
         {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.10"}}},
-        {mria, {git, "https://github.com/emqx/mria", {tag, "0.8.13"}}}
+        {mria, {git, "https://github.com/emqx/mria", {tag, "0.8.15"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,


### PR DESCRIPTION
Changes:
- 0.8.14: fixed EXIT messages leak
- 0.8.15: fixed build for macOS 15