### PR TITLE
fix(locker): return false when no available nodes or rpc timeout

### DIFF
--- a/src/ekka_locker.erl
+++ b/src/ekka_locker.erl
@@ -242,6 +242,8 @@ merge_results([], _, Failed) ->
 merge_results([{true, Res}|ResL], Succ, Failed) ->
     merge_results(ResL, [Res|Succ], Failed);
 merge_results([{false, Res}|ResL], Succ, Failed) ->
+    merge_results(ResL, Succ, [Res|Failed]);
+merge_results([{badrpc, _} = Res | ResL], Succ, Failed) ->
     merge_results(ResL, Succ, [Res|Failed]).
 
 %%--------------------------------------------------------------------

--- a/src/ekka_locker.erl
+++ b/src/ekka_locker.erl
@@ -231,6 +231,8 @@ release_lock(Name, #lock{resource = Resource, owner = Owner}) ->
           end,
     {Res, [node()]}.
 
+merge_results([]) ->
+    {false, []};
 merge_results(ResL) ->
     merge_results(ResL, [], []).
 merge_results([], Succ, []) ->

--- a/test/ekka_locker_SUITE.erl
+++ b/test/ekka_locker_SUITE.erl
@@ -66,3 +66,16 @@ t_acquire_release_all(_) ->
     ?assertEqual({true, [Node]}, ekka_locker:acquire(?SERVER, resource, all)),
     ?assertEqual({true, [Node]}, ekka_locker:release(?SERVER, resource, all)),
     ?assertEqual({true, [Node]}, ekka_locker:release(?SERVER, resource, all)).
+
+t_acquire_should_fail_with_empty_nodelist(_) ->
+    ok = meck:expect(mria_membership, nodelist, fun(_) -> [] end),
+    ?assertEqual([], ets:tab2list(?SERVER)),
+    ?assertEqual({false, []}, ekka_locker:acquire(?SERVER, resource, all)),
+    ?assertEqual([], ets:tab2list(?SERVER)).
+
+t_acquire_should_fail_when_all_nodes_down(_) ->
+    Node = 'node@nowhere',
+    ok = meck:expect(mria_membership, nodelist, fun(_) -> [Node] end),
+    ?assertEqual([], ets:tab2list(?SERVER)),
+    ?assertEqual({false, []}, ekka_locker:acquire(?SERVER, resource, all)),
+    ?assertEqual([], ets:tab2list(?SERVER)).


### PR DESCRIPTION
- acquire/release should return false if result list is empty or all nodes are down.
- failed rpc call should be treated as negative as well. a common error is rpc timeout.

without this fix, it may leave dead locks in the EMQX cluster as the 'locks' are inconsistent in the cluster. 

there is a leak detection `check_lease` but it takes many secends to detect these dead locks.